### PR TITLE
fix(stake): correct Inactive tab + include unbonding validators

### DIFF
--- a/components/AllValidators.jsx
+++ b/components/AllValidators.jsx
@@ -35,12 +35,14 @@ const AllValidators = ({
     )?.delegatedAmount,
   }));
 
-  const allValidatorsUnbondedUsable = allValidatorsBonded.map((el, index) => ({
-    ...el,
-    am_delegatedAmount: delegatedValidators?.find(
-      (element) => element?.operatorAddress == el?.operatorAddress
-    )?.delegatedAmount,
-  }));
+  const allValidatorsUnbondedUsable = allValidatorsUnbonded.map(
+    (el, index) => ({
+      ...el,
+      am_delegatedAmount: delegatedValidators?.find(
+        (element) => element?.operatorAddress == el?.operatorAddress
+      )?.delegatedAmount,
+    })
+  );
 
   const allValidatorsBondedUsableSorted = (sortBy) => {
     let ascending = true;
@@ -266,7 +268,6 @@ const AllValidators = ({
                     }}
                   ></input>
                 </td>
-                {activeValidators ? <td>{index + 1}</td> : null}
                 <td>
                   <div
                     className="d-flex position-relative rounded-circle"

--- a/components/DelegatedValidators.jsx
+++ b/components/DelegatedValidators.jsx
@@ -203,7 +203,6 @@ const DelegatedValidators = ({
                     }}
                   ></input>
                 </td>
-                {activeValidators ? <td>{index + 1}</td> : null}
                 <td>
                   <div
                     className="d-flex position-relative rounded-circle"

--- a/data/queryApi.js
+++ b/data/queryApi.js
@@ -825,11 +825,16 @@ const fetchAllValidatorsUnbonded = async (url) => {
   // use a try catch block for creating rich Error object
   try {
     const client = await getRpcClient();
-    // get the data from cosmos queryClient
+    // The chain query takes a single status string, so we ask for all
+    // validators (status: "") and partition client-side.  Anything that
+    // isn't BOND_STATUS_BONDED (UNBONDING, UNBONDED, UNSPECIFIED) is
+    // surfaced in the Inactive set.
     const { validators } = await client.cosmos.staking.v1beta1.validators({
-      status: "BOND_STATUS_UNBONDED",
+      status: "",
     });
-    allValidatorsUnbonded = validators;
+    allValidatorsUnbonded = validators?.filter?.(
+      (validator) => validator?.status !== "BOND_STATUS_BONDED"
+    );
   } catch (error) {
     console.error(`swr fetcher : url: ${url},  error: ${error}`);
     throw error;


### PR DESCRIPTION
## Summary
The Active/Inactive tab on `/stake` was effectively broken:

1. **Copy-paste bug** at `components/AllValidators.jsx:38` — Inactive panel mapped over `allValidatorsBonded` instead of `allValidatorsUnbonded`, so both tabs rendered the same set.
2. **Unbonding validators dropped entirely** — `data/queryApi.js` only queried `BOND_STATUS_BONDED` and `BOND_STATUS_UNBONDED`. The 5 jailed `BOND_STATUS_UNBONDING` validators showed up nowhere.
3. **Misleading rank cells** — Inactive rows displayed `{index + 1}` as if it were a chain rank.

## Changes
- Fix the `allValidatorsBonded`→`allValidatorsUnbonded` map in `AllValidators.jsx`.
- Switch `fetchAllValidatorsUnbonded` to a no-status query and partition client-side via `validator.status !== "BOND_STATUS_BONDED"` so UNBONDING + UNSPECIFIED + UNBONDED all surface in the Inactive set.
- Drop the misleading rank cells from the Inactive panel of `AllValidators.jsx` and `DelegatedValidators.jsx`.

3 files changed, 16 insertions(+), 11 deletions(-).

## Test plan
- [x] Docker Node 22 build reaches `Generating static pages (10/10)`, `/stake` route emitted.
- [ ] On live `/stake`: Active tab shows BONDED set ranked by voting power; Inactive tab shows UNBONDING ∪ UNBONDED ∪ UNSPECIFIED with rank column hidden.
- [ ] Delegated panel correctly partitions across the two tabs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)