### PR TITLE
fix: pin WalletConnect v2 in web3modal connectors

### DIFF
--- a/data/ethApi.js
+++ b/data/ethApi.js
@@ -176,7 +176,15 @@ const { provider } = configureChains(chains, [
 // create the wagmiClient
 export const wagmiClient = createClient({
   autoConnect: true,
-  connectors: modalConnectors({ appName: "web3Modal", chains }),
+  connectors: modalConnectors({
+    appName: "web3Modal",
+    chains,
+    // web3modal 2.1.x defaults to WalletConnect v1, whose public bridge
+    // servers were shut down in 2023 (wss://*.bridge.walletconnect.org no
+    // longer resolves). Pin v2, which uses the live relay.walletconnect.com.
+    version: "2",
+    projectId: walletConnectProjectID,
+  }),
   provider,
 });
 // now create ethereum client using wagmi client


### PR DESCRIPTION
Every page load currently attempts websocket connections to `wss://u.bridge.walletconnect.org` / `wss://k.bridge.walletconnect.org` (WalletConnect v1 bridges), which fail with `ERR_NAME_NOT_RESOLVED` — those hostnames were decommissioned when WalletConnect shut down v1 in 2023. Result: console error spam on every visit and a dead WalletConnect pairing option.

Root cause: `modalConnectors({ appName, chains })` in `data/ethApi.js` omits `version`, and `@web3modal/ethereum` 2.1.1 defaults it to `"1"` (verified in the published package: `const o = t ?? "1"` in `dist/index.js`). The fix pins `version: "2"` with the project id already defined in the same file (and already used by `walletConnectProvider`), moving pairing to the live `relay.walletconnect.com` infrastructure.

Verified: `next build` passes with the change (all routes compile). One config object touched, no dependency changes.