### PR TITLE
fix: declare eslint environments

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,9 @@
 {
+  "env": {
+    "browser": true,
+    "node": true,
+    "es2021": true
+  },
   "extends": ["next/core-web-vitals", "prettier"],
   "plugins": ["prettier", "unused-imports"],
   "rules": {


### PR DESCRIPTION
The eslint config declares no `env`, so every ES2015+ global (`Promise`, `Set`, `BigInt`, `Uint8Array`) is flagged as undefined — 19 false `no-undef` warnings across the codebase, drowning out what the rule exists to catch. This declares the environments the app actually runs in (browser + node + es2021).

Verified: `no-undef` warnings 19 → 0 with the rule still active (a real undeclared identifier still warns); no other lint output changed.