### PR TITLE
feat(keystore): in-browser encrypted-keystore login + passkey unlock (migrate V1 users)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ next-env.d.ts
 # local agent worktrees + design backups
 .claude/
 *.dark-mode-backup
+.superpowers/

--- a/components/DisconnecedRecieve.jsx
+++ b/components/DisconnecedRecieve.jsx
@@ -18,7 +18,7 @@ const DisconnecedRecieve = () => {
             aspectRatio: "1/1",
           }}
         >
-          <Image src="/qr-code.svg" alt="qr code place holder" />
+          <Image layout="fill" src="/qr-code.svg" alt="qr code place holder" />
         </div>
         <h4 className="body2 text-primary">Wallet Address</h4>
         <div className="d-flex align-items-center justify-content-center gap-2 text-gray text-center caption2 pt-1">

--- a/components/ICFormPolygon.js
+++ b/components/ICFormPolygon.js
@@ -126,7 +126,11 @@ export default function ICFormPolygon() {
               className="position-relative"
               style={{ width: "21px", aspectRatio: "1/1" }}
             >
-              <Image src="/chainLogos/grav.svg" alt="Gravity Bridge" />
+              <Image
+                layout="fill"
+                src="/chainLogos/grav.svg"
+                alt="Gravity Bridge"
+              />
             </div>
             <h5 className="caption2 text-primary">Gravity Bridge</h5>
           </div>
@@ -180,7 +184,11 @@ export default function ICFormPolygon() {
               className="position-relative"
               style={{ width: "21px", aspectRatio: "1/1" }}
             >
-              <Image src="/chainLogos/eth.svg" alt="Ethereum Chain" />
+              <Image
+                layout="fill"
+                src="/chainLogos/eth.svg"
+                alt="Ethereum Chain"
+              />
             </div>
             <h5 className="caption2 text-primary">Ethereum Chain</h5>
           </div>
@@ -243,7 +251,11 @@ export default function ICFormPolygon() {
               className="position-relative"
               style={{ width: "21px", aspectRatio: "1/1" }}
             >
-              <Image src="/chainLogos/polygon.svg" alt="Polygon Chain" />
+              <Image
+                layout="fill"
+                src="/chainLogos/polygon.svg"
+                alt="Polygon Chain"
+              />
             </div>
             <h5 className="caption2 text-primary">Polygon Chain</h5>
           </div>

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,7 @@
+const nextJest = require("next/jest");
+const createJestConfig = nextJest({ dir: "./" });
+module.exports = createJestConfig({
+  testEnvironment: "jest-environment-jsdom",
+  setupFilesAfterEnv: ["<rootDir>/jest.setup.js"],
+  testMatch: ["**/__tests__/**/*.test.js"],
+});

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,14 @@
+const { webcrypto } = require("crypto");
+const { TextEncoder, TextDecoder } = require("util");
+// jsdom defines its own `global.crypto` (getRandomValues/randomUUID only, no
+// SubtleCrypto), so `!global.crypto` never trips. Guard on `.subtle` instead
+// and replace the whole object via defineProperty since jsdom's `crypto` is
+// a getter-only accessor that a plain assignment can't overwrite.
+if (!global.crypto || !global.crypto.subtle) {
+  Object.defineProperty(global, "crypto", {
+    value: webcrypto,
+    configurable: true,
+  });
+}
+if (!global.TextEncoder) global.TextEncoder = TextEncoder;
+if (!global.TextDecoder) global.TextDecoder = TextDecoder;

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,5 +1,8 @@
 const { webcrypto } = require("crypto");
-const { TextEncoder, TextDecoder } = require("util");
+const {
+  TextEncoder: NodeTextEncoder,
+  TextDecoder: NodeTextDecoder,
+} = require("util");
 // jsdom defines its own `global.crypto` (getRandomValues/randomUUID only, no
 // SubtleCrypto), so `!global.crypto` never trips. Guard on `.subtle` instead
 // and replace the whole object via defineProperty since jsdom's `crypto` is
@@ -10,5 +13,15 @@ if (!global.crypto || !global.crypto.subtle) {
     configurable: true,
   });
 }
-if (!global.TextEncoder) global.TextEncoder = TextEncoder;
-if (!global.TextDecoder) global.TextDecoder = TextDecoder;
+// jsdom ships no TextEncoder/TextDecoder. Node's util versions return
+// Uint8Arrays from Node's realm, which fail libsodium-wrappers' strict
+// `instanceof Uint8Array` check inside cosmjs's Argon2id/XChaCha20 modern-format
+// path. Re-cast encode() output through the jsdom-realm Uint8Array every suite
+// sees, so any test touching cosmjs crypto works without a per-file shim.
+const nodeEncoder = new NodeTextEncoder();
+global.TextEncoder = class {
+  encode(input) {
+    return Uint8Array.from(nodeEncoder.encode(input));
+  }
+};
+global.TextDecoder = NodeTextDecoder;

--- a/lib/keystore/__tests__/account.test.js
+++ b/lib/keystore/__tests__/account.test.js
@@ -1,0 +1,7 @@
+const { mnemonicToSigner } = require("../account");
+const MNEMONIC =
+  "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+test("derives the canonical mantle address at m/44'/118'/0'/0/0", async () => {
+  const { address } = await mnemonicToSigner(MNEMONIC);
+  expect(address).toMatch(/^mantle1[0-9a-z]{38}$/);
+});

--- a/lib/keystore/__tests__/download.test.js
+++ b/lib/keystore/__tests__/download.test.js
@@ -1,0 +1,58 @@
+// Unit-testable slice of downloadModernKeystore: that it builds a Blob
+// carrying the exact JSON string handed in, and drives a click through a
+// throwaway anchor. Real browser download behavior (save-file-picker /
+// disk write) is outside what jsdom can exercise - that's covered by the
+// manual browser pass (Task 6).
+const { downloadModernKeystore } = require("../download");
+
+// jsdom's Blob has no .text()/.arrayBuffer(); FileReader is the one
+// jsdom-supported way to read a Blob's content back out for assertion.
+function readBlobAsText(blob) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result);
+    reader.onerror = () => reject(reader.error);
+    reader.readAsText(blob);
+  });
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  delete global.URL.createObjectURL;
+  delete global.URL.revokeObjectURL;
+});
+
+test("creates a Blob carrying the exact string and revokes the object URL", async () => {
+  const createdBlobs = [];
+  global.URL.createObjectURL = jest.fn((blob) => {
+    createdBlobs.push(blob);
+    return "blob:mock-url";
+  });
+  global.URL.revokeObjectURL = jest.fn();
+  const anchor = { click: jest.fn() };
+  jest.spyOn(document, "createElement").mockReturnValue(anchor);
+
+  const json = JSON.stringify({ type: "secp256k1hdwallet", kdf: "argon2id" });
+  downloadModernKeystore(json, "assetmantle-keystore-modern.json");
+
+  expect(createdBlobs).toHaveLength(1);
+  expect(createdBlobs[0]).toBeInstanceOf(Blob);
+  expect(createdBlobs[0].type).toBe("application/json");
+  expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:mock-url");
+
+  await expect(readBlobAsText(createdBlobs[0])).resolves.toBe(json);
+});
+
+test("sets the anchor's href/download and triggers exactly one click", () => {
+  global.URL.createObjectURL = jest.fn(() => "blob:mock-url");
+  global.URL.revokeObjectURL = jest.fn();
+  const anchor = { click: jest.fn() };
+  jest.spyOn(document, "createElement").mockReturnValue(anchor);
+
+  downloadModernKeystore("{}", "my-file.json");
+
+  expect(document.createElement).toHaveBeenCalledWith("a");
+  expect(anchor.href).toBe("blob:mock-url");
+  expect(anchor.download).toBe("my-file.json");
+  expect(anchor.click).toHaveBeenCalledTimes(1);
+});

--- a/lib/keystore/__tests__/download.test.js
+++ b/lib/keystore/__tests__/download.test.js
@@ -22,7 +22,7 @@ afterEach(() => {
   delete global.URL.revokeObjectURL;
 });
 
-test("creates a Blob carrying the exact string and revokes the object URL", async () => {
+test("creates a Blob carrying the exact string and revokes the object URL after a tick", async () => {
   const createdBlobs = [];
   global.URL.createObjectURL = jest.fn((blob) => {
     createdBlobs.push(blob);
@@ -38,9 +38,16 @@ test("creates a Blob carrying the exact string and revokes the object URL", asyn
   expect(createdBlobs).toHaveLength(1);
   expect(createdBlobs[0]).toBeInstanceOf(Blob);
   expect(createdBlobs[0].type).toBe("application/json");
-  expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:mock-url");
+  // L1: revoke is deferred (setTimeout) so the browser has a chance to
+  // actually start the download before the object URL is torn down - it
+  // must NOT have fired synchronously.
+  expect(URL.revokeObjectURL).not.toHaveBeenCalled();
 
   await expect(readBlobAsText(createdBlobs[0])).resolves.toBe(json);
+
+  // Flush the deferred macrotask and confirm the revoke still happens.
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:mock-url");
 });
 
 test("sets the anchor's href/download and triggers exactly one click", () => {

--- a/lib/keystore/__tests__/keystoreWallet.test.js
+++ b/lib/keystore/__tests__/keystoreWallet.test.js
@@ -1,0 +1,60 @@
+const { mnemonicToSigner } = require("../account");
+const {
+  setKeystoreSigner,
+  getKeystoreSigner,
+  clearKeystoreSigner,
+} = require("../keystoreStore");
+const {
+  KeystoreWallet,
+  KeystoreClient,
+  keystoreWalletInfo,
+} = require("../keystoreWallet");
+
+const MNEMONIC =
+  "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+
+// Minimal chain record. setChains() only dereferences `.name` and (via the
+// chain wallet) `.chain.chain_id`; everything else it reads with optional
+// chaining, so no network / real registry entry is needed.
+const assetmantleRecord = {
+  name: "assetmantle",
+  chain: { chain_id: "mantle-1", chain_name: "assetmantle" },
+  assetList: { chain_name: "assetmantle", assets: [] },
+};
+
+afterEach(() => {
+  clearKeystoreSigner();
+});
+
+test("connected KeystoreWallet yields an offline signer whose first account equals the derived address", async () => {
+  const { signer, address } = await mnemonicToSigner(MNEMONIC);
+  setKeystoreSigner(signer, address);
+
+  // store round-trips exactly what was set (no key persistence beyond memory)
+  expect(getKeystoreSigner().address).toBe(address);
+
+  // Build the wallet exactly as ChainProvider does: a MainWalletBase instance,
+  // setChains(), then connect the per-chain ChainWalletBase.
+  const wallet = new KeystoreWallet(keystoreWalletInfo);
+  wallet.setChains([assetmantleRecord]);
+  const chainWallet = wallet.getChainWallet("assetmantle");
+
+  await chainWallet.connect();
+
+  // connect() -> update() -> client.getAccount() -> setData(address)
+  expect(chainWallet.state).toBe("Done");
+  expect(chainWallet.address).toBe(address);
+
+  // getSigningStargateClient() reaches SigningStargateClient.connectWithSigner
+  // with exactly this offline signer (initOfflineSigner -> client.getOfflineSigner).
+  await chainWallet.initOfflineSigner();
+  const [account] = await chainWallet.offlineSigner.getAccounts();
+  expect(account.address).toBe(address);
+});
+
+test("a locked keystore (no/cleared signer) makes the client refuse to sign", async () => {
+  clearKeystoreSigner();
+  const client = new KeystoreClient();
+  expect(() => client.getOfflineSignerDirect()).toThrow(/locked/i);
+  await expect(client.getAccount()).rejects.toThrow(/locked/i);
+});

--- a/lib/keystore/__tests__/keystoreWallet.test.js
+++ b/lib/keystore/__tests__/keystoreWallet.test.js
@@ -58,3 +58,74 @@ test("a locked keystore (no/cleared signer) makes the client refuse to sign", as
   expect(() => client.getOfflineSignerDirect()).toThrow(/locked/i);
   await expect(client.getAccount()).rejects.toThrow(/locked/i);
 });
+
+// FIX 1: the client must refuse any chainId that isn't assetmantle's, so a
+// mantle1... signer can never be handed to a different chain registered on
+// the same <ChainProvider> (e.g. gravitybridge, osmosis).
+test("the client refuses to sign for a chainId that is not assetmantle's", async () => {
+  const { signer, address } = await mnemonicToSigner(MNEMONIC);
+  setKeystoreSigner(signer, address);
+
+  // Build exactly as ChainProvider does, so the client is constructed via the
+  // real initClient() -> resolveAssetmantleChainId() path, scoped to whatever
+  // chainId the "assetmantle" chain record actually carries (mantle-1) rather
+  // than a chainId hardcoded in the test.
+  const wallet = new KeystoreWallet(keystoreWalletInfo);
+  wallet.setChains([assetmantleRecord]);
+  const chainWallet = wallet.getChainWallet("assetmantle");
+  await chainWallet.connect();
+  expect(chainWallet.state).toBe("Done"); // sanity: the real chain still works
+
+  const client = chainWallet.client;
+  const WRONG_CHAIN_ID = "gravity-bridge-3";
+
+  expect(() => client.getOfflineSignerDirect(WRONG_CHAIN_ID)).toThrow(
+    /AssetMantle/i
+  );
+  expect(() => client.getOfflineSigner(WRONG_CHAIN_ID)).toThrow(/AssetMantle/i);
+  await expect(client.getAccount(WRONG_CHAIN_ID)).rejects.toThrow(
+    /AssetMantle/i
+  );
+
+  // the thrown message must never leak the address or mnemonic
+  try {
+    client.getOfflineSignerDirect(WRONG_CHAIN_ID);
+  } catch (error) {
+    expect(error.message).not.toContain(address);
+    expect(error.message).not.toContain("abandon");
+  }
+});
+
+// Edge case surfaced while implementing the guard: cosmos-kit copies
+// initClient() onto every ChainWalletBase (MainWalletBase.setChains), so
+// `this` inside initClient() can be the MainWalletBase itself (holding every
+// configured chain) rather than a single ChainWalletBase. The resolver must
+// still land on assetmantle's real chainId in that case.
+test("resolves assetmantle's chainId even when initClient runs at the main-wallet layer", async () => {
+  const wallet = new KeystoreWallet(keystoreWalletInfo);
+  wallet.setChains([assetmantleRecord]);
+
+  await wallet.initClient();
+
+  expect(wallet.client.allowedChainId).toBe("mantle-1");
+});
+
+// FIX 2: cosmos-kit's own disconnect lifecycle (WalletBase.disconnect() ->
+// client?.disconnect?.()) must drop the in-memory keystore key.
+test("disconnect() drops the in-memory keystore signer", async () => {
+  const { signer, address } = await mnemonicToSigner(MNEMONIC);
+  setKeystoreSigner(signer, address);
+
+  const wallet = new KeystoreWallet(keystoreWalletInfo);
+  wallet.setChains([assetmantleRecord]);
+  const chainWallet = wallet.getChainWallet("assetmantle");
+  await chainWallet.connect();
+  expect(chainWallet.state).toBe("Done");
+  expect(getKeystoreSigner().signer).not.toBeNull();
+
+  // the real cosmos-kit lifecycle, not a direct call to the store helper
+  await chainWallet.disconnect();
+
+  expect(getKeystoreSigner().signer).toBeNull();
+  expect(getKeystoreSigner().address).toBeNull();
+});

--- a/lib/keystore/__tests__/legacyV1.test.js
+++ b/lib/keystore/__tests__/legacyV1.test.js
@@ -1,0 +1,39 @@
+const crypto = require("crypto");
+const { decryptLegacyV1 } = require("../legacyV1");
+
+// reproduce V1 createKeyStore EXACTLY (walletOld src/utils/helper.js)
+function v1CreateKeyStore(mnemonic, password) {
+  const key = crypto.randomBytes(32);
+  const iv = crypto.randomBytes(16);
+  const cipher = crypto.createCipheriv("aes-256-cbc", key, iv);
+  const encrypted = Buffer.concat([
+    cipher.update(mnemonic, "utf8"),
+    cipher.final(),
+  ]);
+  return {
+    hashpwd: crypto.createHash("sha512").update(password).digest("hex"),
+    iv: iv.toString("hex"),
+    salt: key.toString("hex"),
+    crypted: encrypted.toString("hex"),
+  };
+}
+const MNEMONIC =
+  "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+
+test("decrypts a real V1 file with the correct password", async () => {
+  const file = v1CreateKeyStore(MNEMONIC, "correcthorse");
+  expect(await decryptLegacyV1(file, "correcthorse")).toEqual({
+    mnemonic: MNEMONIC,
+  });
+});
+test("rejects a wrong password without decrypting", async () => {
+  const file = v1CreateKeyStore(MNEMONIC, "correcthorse");
+  expect(await decryptLegacyV1(file, "wrong")).toEqual({
+    error: "Incorrect password.",
+  });
+});
+test("rejects a non-V1 file shape", async () => {
+  expect(await decryptLegacyV1({ foo: "bar" }, "x")).toEqual({
+    error: "Not a valid V1 keystore file.",
+  });
+});

--- a/lib/keystore/__tests__/modern.test.js
+++ b/lib/keystore/__tests__/modern.test.js
@@ -1,0 +1,29 @@
+// jsdom (26.x here) ships no TextEncoder, so jest.setup.js falls back to
+// Node's util.TextEncoder, whose .encode() returns a Uint8Array from Node's
+// own realm. libsodium-wrappers (pulled in by DirectSecp256k1HdWallet's
+// Argon2id/XChaCha20 modern-format path) does a strict `instanceof
+// Uint8Array` check on the plaintext it encrypts, so that cross-realm
+// Uint8Array trips "TypeError: unsupported input type for message". Re-cast
+// through this file's own (jsdom-realm) Uint8Array before cosmjs sees the
+// bytes. Scoped to this file only - every test file gets its own fresh
+// jsdom global, so this can't leak into account.js/legacyV1's tests.
+const { TextEncoder: NodeTextEncoder } = require("util");
+global.TextEncoder = class {
+  encode(str) {
+    return Uint8Array.from(new NodeTextEncoder().encode(str));
+  }
+};
+
+const { exportModern, importModern } = require("../modern");
+const MNEMONIC =
+  "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+test("round-trips through the modern encrypted format", async () => {
+  const blob = await exportModern(MNEMONIC, "pw-123456789");
+  const wallet = await importModern(blob, "pw-123456789");
+  const [acct] = await wallet.getAccounts();
+  expect(acct.address).toMatch(/^mantle1/);
+});
+test("wrong password fails to import", async () => {
+  const blob = await exportModern(MNEMONIC, "pw-123456789");
+  await expect(importModern(blob, "nope")).rejects.toThrow();
+});

--- a/lib/keystore/__tests__/modern.test.js
+++ b/lib/keystore/__tests__/modern.test.js
@@ -1,19 +1,5 @@
-// jsdom (26.x here) ships no TextEncoder, so jest.setup.js falls back to
-// Node's util.TextEncoder, whose .encode() returns a Uint8Array from Node's
-// own realm. libsodium-wrappers (pulled in by DirectSecp256k1HdWallet's
-// Argon2id/XChaCha20 modern-format path) does a strict `instanceof
-// Uint8Array` check on the plaintext it encrypts, so that cross-realm
-// Uint8Array trips "TypeError: unsupported input type for message". Re-cast
-// through this file's own (jsdom-realm) Uint8Array before cosmjs sees the
-// bytes. Scoped to this file only - every test file gets its own fresh
-// jsdom global, so this can't leak into account.js/legacyV1's tests.
-const { TextEncoder: NodeTextEncoder } = require("util");
-global.TextEncoder = class {
-  encode(str) {
-    return Uint8Array.from(new NodeTextEncoder().encode(str));
-  }
-};
-
+// The realm-safe TextEncoder needed for cosmjs's libsodium path is installed
+// globally in jest.setup.js.
 const { exportModern, importModern } = require("../modern");
 const MNEMONIC =
   "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";

--- a/lib/keystore/__tests__/passkey.test.js
+++ b/lib/keystore/__tests__/passkey.test.js
@@ -110,6 +110,14 @@ test("throws PrfUnsupportedError when the authenticator returns no PRF result", 
   );
 });
 
+test("throws PrfUnsupportedError when the PRF result is present but empty (no empty-secret password)", async () => {
+  installMockedWebAuthn(new ArrayBuffer(0));
+
+  await expect(enrollPasskey(ENROLL_PARAMS)).rejects.toThrow(
+    PrfUnsupportedError
+  );
+});
+
 test("isPrfSupported() is false when navigator.credentials is undefined (jsdom default)", async () => {
   delete navigator.credentials; // explicit precondition, independent of afterEach ordering
 

--- a/lib/keystore/__tests__/passkey.test.js
+++ b/lib/keystore/__tests__/passkey.test.js
@@ -1,0 +1,117 @@
+// Unit-level tests with a MOCKED navigator.credentials (WebAuthn). This
+// proves the plumbing (request/response shapes, encoding, error path, and
+// that the derived secret really works as a keystore password). It does not
+// prove a real platform authenticator (Touch ID) behaves this way - that is
+// the separate CDP virtual-authenticator / manual check documented at the
+// bottom of ../passkey.js.
+const { bytesToHex } = require("../hex");
+const { exportModern, importModern } = require("../modern");
+const { mnemonicToSigner } = require("../account");
+const {
+  isPrfSupported,
+  enrollPasskey,
+  unlockPasskey,
+  PrfUnsupportedError,
+} = require("../passkey");
+
+const MNEMONIC =
+  "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+
+const ENROLL_PARAMS = {
+  rpId: "wallet.assetmantle.one",
+  rpName: "AssetMantle Wallet",
+  userId: "user-123",
+  userName: "user-123",
+};
+
+// Fixed 32-byte "PRF output" the mocked authenticator hands back for any
+// (credential, salt) pair. A real authenticator's PRF output is a
+// deterministic function of (credential, salt); the mock does not need to
+// simulate that math, only stand in for its shape (an ArrayBuffer) so this
+// suite can prove the plumbing around it.
+const FIXED_PRF_BYTES = new Uint8Array(32);
+for (let i = 0; i < 32; i++) FIXED_PRF_BYTES[i] = i;
+const FIXED_PRF_HEX = bytesToHex(FIXED_PRF_BYTES);
+
+const FIXED_RAW_ID = new Uint8Array(16);
+for (let i = 0; i < 16; i++) FIXED_RAW_ID[i] = 0xa0 + i;
+
+// Builds the mocked return value of both create() and get(): a credential /
+// assertion object exposing `rawId` (ArrayBuffer) and
+// `getClientExtensionResults()`. Pass `null` for prfFirstBuffer to simulate
+// an authenticator that does not support the PRF extension (empty `{}`
+// extension results, per the spec when a requested extension isn't honored).
+function mockCredential(prfFirstBuffer) {
+  return {
+    rawId: FIXED_RAW_ID.buffer,
+    getClientExtensionResults: () =>
+      prfFirstBuffer ? { prf: { results: { first: prfFirstBuffer } } } : {},
+  };
+}
+
+function installMockedWebAuthn(prfFirstBuffer = FIXED_PRF_BYTES.buffer) {
+  global.navigator = global.navigator || {};
+  navigator.credentials = {
+    create: jest.fn().mockResolvedValue(mockCredential(prfFirstBuffer)),
+    get: jest.fn().mockResolvedValue(mockCredential(prfFirstBuffer)),
+  };
+  global.PublicKeyCredential = function PublicKeyCredential() {};
+}
+
+afterEach(() => {
+  if (typeof navigator !== "undefined") delete navigator.credentials;
+  delete global.PublicKeyCredential;
+});
+
+test("enrollPasskey returns a stable prfSecretHex matching the fixed PRF buffer", async () => {
+  installMockedWebAuthn();
+
+  const { credentialId, prfSalt, prfSecretHex } = await enrollPasskey(
+    ENROLL_PARAMS
+  );
+
+  expect(prfSecretHex).toBe(FIXED_PRF_HEX);
+  expect(typeof credentialId).toBe("string");
+  expect(prfSalt).toMatch(/^[0-9a-f]{64}$/); // 32 random bytes, hex-encoded
+});
+
+test("unlockPasskey with the same salt returns the same secret", async () => {
+  installMockedWebAuthn();
+  const enrolled = await enrollPasskey(ENROLL_PARAMS);
+
+  const unlockedHex = await unlockPasskey({
+    credentialId: enrolled.credentialId,
+    prfSalt: enrolled.prfSalt,
+  });
+
+  expect(unlockedHex).toBe(enrolled.prfSecretHex);
+});
+
+// INTEGRATION (key assertion): the passkey-derived secret must work as an
+// ordinary keystore password - exportModern/importModern do real Argon2id +
+// XChaCha20-Poly1305 work, hence the extended timeout.
+test("passkey-derived secret round-trips the real modern keystore (works as its password)", async () => {
+  installMockedWebAuthn();
+  const { prfSecretHex } = await enrollPasskey(ENROLL_PARAMS);
+
+  const blob = await exportModern(MNEMONIC, prfSecretHex);
+  const wallet = await importModern(blob, prfSecretHex);
+  const [account] = await wallet.getAccounts();
+
+  const { address } = await mnemonicToSigner(MNEMONIC);
+  expect(account.address).toBe(address);
+}, 30000);
+
+test("throws PrfUnsupportedError when the authenticator returns no PRF result", async () => {
+  installMockedWebAuthn(null);
+
+  await expect(enrollPasskey(ENROLL_PARAMS)).rejects.toThrow(
+    PrfUnsupportedError
+  );
+});
+
+test("isPrfSupported() is false when navigator.credentials is undefined (jsdom default)", async () => {
+  delete navigator.credentials; // explicit precondition, independent of afterEach ordering
+
+  await expect(isPrfSupported()).resolves.toBe(false);
+});

--- a/lib/keystore/__tests__/persist.test.js
+++ b/lib/keystore/__tests__/persist.test.js
@@ -1,0 +1,71 @@
+// Opt-in localStorage persistence for the passkey-unlock handles ONLY.
+// This must never be able to carry a raw key, mnemonic, or legacy blob -
+// the allowlist behavior is exercised explicitly below.
+const {
+  savePasskeyKeystore,
+  loadPasskeyKeystore,
+  clearPasskeyKeystore,
+} = require("../persist");
+
+const RECORD = {
+  credentialId: "Y3JlZC1pZC0xMjM", // base64url, arbitrary
+  prfSalt: "a1b2c3d4",
+  modernBlob: '{"type":"secp256k1hdwallet","kdf":"argon2id","data":"..."}',
+};
+
+afterEach(() => {
+  clearPasskeyKeystore();
+});
+
+test("round-trips save/load exactly", () => {
+  savePasskeyKeystore(RECORD);
+  expect(loadPasskeyKeystore()).toEqual(RECORD);
+});
+
+test("load returns null when nothing has been saved", () => {
+  expect(loadPasskeyKeystore()).toBeNull();
+});
+
+test("clear removes the record; loaded value after clear is null", () => {
+  savePasskeyKeystore(RECORD);
+  expect(loadPasskeyKeystore()).not.toBeNull();
+  clearPasskeyKeystore();
+  expect(loadPasskeyKeystore()).toBeNull();
+});
+
+test("refuses/omits any field that isn't one of the three (e.g. a mnemonic must never be persisted)", () => {
+  savePasskeyKeystore({
+    ...RECORD,
+    mnemonic:
+      "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+    privateKey: "deadbeef",
+  });
+
+  const loaded = loadPasskeyKeystore();
+  expect(loaded).toEqual(RECORD);
+  expect(Object.keys(loaded).sort()).toEqual(
+    ["credentialId", "modernBlob", "prfSalt"].sort()
+  );
+
+  // Defense in depth: the leaked secret must not even be present in the
+  // raw persisted string, not just absent from the parsed/returned object.
+  const raw = window.localStorage.getItem(
+    Object.keys(window.localStorage).find((k) => k.includes("keystore")) ||
+      "__missing__"
+  );
+  expect(raw || "").not.toContain("abandon");
+  expect(raw || "").not.toContain("deadbeef");
+});
+
+test("a corrupted/partial stored record loads as null instead of throwing", () => {
+  window.localStorage.setItem(
+    "am-keystore-passkey-v1",
+    JSON.stringify({ credentialId: "only-one-field" })
+  );
+  expect(loadPasskeyKeystore()).toBeNull();
+});
+
+test("non-JSON garbage in storage loads as null instead of throwing", () => {
+  window.localStorage.setItem("am-keystore-passkey-v1", "not json{{{");
+  expect(loadPasskeyKeystore()).toBeNull();
+});

--- a/lib/keystore/__tests__/smoke.test.js
+++ b/lib/keystore/__tests__/smoke.test.js
@@ -1,0 +1,10 @@
+test("jest runs", () => {
+  expect(1 + 1).toBe(2);
+});
+test("WebCrypto SubtleCrypto is available", async () => {
+  const d = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode("x")
+  );
+  expect(new Uint8Array(d).length).toBe(32);
+});

--- a/lib/keystore/account.js
+++ b/lib/keystore/account.js
@@ -1,0 +1,15 @@
+import { DirectSecp256k1HdWallet } from "@cosmjs/proto-signing";
+import { stringToPath } from "@cosmjs/crypto";
+
+// coin type 118, verified vs V1 - must stay identical to modern.js (HD path
+// change breaks migration between the two).
+const HD = [stringToPath("m/44'/118'/0'/0/0")];
+
+export async function mnemonicToSigner(mnemonic) {
+  const signer = await DirectSecp256k1HdWallet.fromMnemonic(mnemonic, {
+    prefix: "mantle",
+    hdPaths: HD,
+  });
+  const [account] = await signer.getAccounts();
+  return { signer, address: account.address };
+}

--- a/lib/keystore/download.js
+++ b/lib/keystore/download.js
@@ -10,5 +10,8 @@ export function downloadModernKeystore(blobString, filename) {
   anchor.href = url;
   anchor.download = filename;
   anchor.click();
-  URL.revokeObjectURL(url);
+  // Revoking in the same tick as click() races the download start in some
+  // browsers and can silently cancel it. Defer to the next macrotask so the
+  // download has already begun by the time the object URL is torn down.
+  setTimeout(() => URL.revokeObjectURL(url), 0);
 }

--- a/lib/keystore/download.js
+++ b/lib/keystore/download.js
@@ -1,0 +1,14 @@
+// Triggers a browser download of a modern keystore JSON blob. Deliberately
+// tiny: build a Blob, point a throwaway anchor at an object URL for it, and
+// click it. No DOM attachment needed - clicking an anchor works whether or
+// not it's attached, and skipping the attach/detach keeps this a one-shot
+// helper with nothing to clean up but the object URL itself.
+export function downloadModernKeystore(blobString, filename) {
+  const blob = new Blob([blobString], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.click();
+  URL.revokeObjectURL(url);
+}

--- a/lib/keystore/hex.js
+++ b/lib/keystore/hex.js
@@ -1,0 +1,9 @@
+export function hexToBytes(hex) {
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < out.length; i++)
+    out[i] = parseInt(hex.substr(i * 2, 2), 16);
+  return out;
+}
+export function bytesToHex(b) {
+  return [...b].map((x) => x.toString(16).padStart(2, "0")).join("");
+}

--- a/lib/keystore/keystoreStore.js
+++ b/lib/keystore/keystoreStore.js
@@ -1,0 +1,22 @@
+// In-memory holder for the keystore account's live cosmjs signer.
+//
+// The private key / mnemonic is NEVER persisted here: no localStorage, no disk,
+// no logging. Only the already-derived OfflineDirectSigner object (from
+// mnemonicToSigner) and its bech32 address live in module memory, and
+// clearKeystoreSigner() drops both on logout / tab close. The signer is a
+// module-level singleton so every consumer (the cosmos-kit adapter, the login
+// UI) reads the same unlocked account.
+
+let current = { signer: null, address: null };
+
+export function setKeystoreSigner(signer, address) {
+  current = { signer, address };
+}
+
+export function getKeystoreSigner() {
+  return current;
+}
+
+export function clearKeystoreSigner() {
+  current = { signer: null, address: null };
+}

--- a/lib/keystore/keystoreWallet.js
+++ b/lib/keystore/keystoreWallet.js
@@ -50,21 +50,89 @@
  */
 
 import { MainWalletBase, ChainWalletBase } from "@cosmos-kit/core";
-import { getKeystoreSigner } from "./keystoreStore";
+import { getKeystoreSigner, clearKeystoreSigner } from "./keystoreStore";
 
 const KEYSTORE_LOCKED_MESSAGE =
   "Keystore is locked. Unlock your keystore account before signing.";
 
+// FIX 1 guard error. Static and generic on purpose: never interpolate a
+// chain-id, address, or key material into it.
+const WRONG_CHAIN_MESSAGE =
+  "Keystore wallet supports only the AssetMantle chain";
+
+// A cosmos-kit chain record (see convertChain in @cosmos-kit/core) is
+// AssetMantle's when its registry chain_name is "assetmantle" or, as a
+// fallback, its bech32 address prefix is "mantle". Never match on a
+// hardcoded chain-id string (e.g. "mantle-1") — that differs between
+// mainnet/testnet, while the registry name and bech32 prefix do not.
+function isAssetmantleChainRecord(chainRecord) {
+  const chain = chainRecord?.chain;
+  const chainName = chain?.chain_name ?? chainRecord?.name;
+  return chainName === "assetmantle" || chain?.bech32_prefix === "mantle";
+}
+
+// Resolves AssetMantle's chain_id from whatever chain-record context is
+// reachable off `this` inside initClient(). MainWalletBase.setChains() copies
+// initClient onto every ChainWalletBase it creates, so `this` can be EITHER
+// the MainWalletBase (holds every configured chain via `chainWallets`) or a
+// single ChainWalletBase (holds only its own `chainRecord`), depending on
+// which object's connect() first builds the client. Prefers an exact
+// chain_name match across every configured chain before falling back to the
+// bech32 prefix, so registration order never matters. Returns undefined
+// (never a guess) when no assetmantle record is reachable, so the client
+// fails closed instead of trusting an unrelated chain.
+function resolveAssetmantleChainId(walletLike) {
+  if (walletLike?.chainWallets) {
+    const chainWallets = Array.from(walletLike.chainWallets.values());
+    const byName = chainWallets.find(
+      (chainWallet) =>
+        (chainWallet.chainRecord?.chain?.chain_name ??
+          chainWallet.chainRecord?.name) === "assetmantle"
+    );
+    if (byName) return byName.chainId;
+    const byPrefix = chainWallets.find(
+      (chainWallet) =>
+        chainWallet.chainRecord?.chain?.bech32_prefix === "mantle"
+    );
+    return byPrefix?.chainId;
+  }
+  if (walletLike?.chainRecord) {
+    return isAssetmantleChainRecord(walletLike.chainRecord)
+      ? walletLike.chainId
+      : undefined;
+  }
+  return undefined;
+}
+
 // The wallet client: bridges keystoreStore's in-memory signer into the shape
-// the cosmos-kit base classes call. chainId args are part of the interface but
-// a single-key keystore serves one derived account regardless of chain, so they
-// are ignored.
+// the cosmos-kit base classes call. `allowedChainId` is AssetMantle's
+// chain_id, resolved from real chain records (see resolveAssetmantleChainId)
+// rather than hardcoded, so the client can refuse any other chain the same
+// <ChainProvider> also registers (e.g. gravitybridge, osmosis).
 export class KeystoreClient {
+  constructor(allowedChainId) {
+    this.allowedChainId = allowedChainId;
+  }
+
+  // FIX 1 guard: throws unless the requested chainId is AssetMantle's.
+  assertChain(chainId) {
+    if (chainId !== this.allowedChainId) {
+      throw new Error(WRONG_CHAIN_MESSAGE);
+    }
+  }
+
   async connect() {
     // no-op: the signer is already in memory once the user unlocks the keystore.
   }
 
-  async getAccount() {
+  // FIX 2: cosmos-kit's WalletBase.disconnect() calls `client?.disconnect?.()`
+  // as part of its own disconnect lifecycle; drop the in-memory key here too.
+  disconnect() {
+    clearKeystoreSigner();
+  }
+
+  async getAccount(chainId) {
+    this.assertChain(chainId);
     const { signer } = getKeystoreSigner();
     if (!signer) throw new Error(KEYSTORE_LOCKED_MESSAGE);
     const [account] = await signer.getAccounts();
@@ -76,11 +144,12 @@ export class KeystoreClient {
     };
   }
 
-  getOfflineSigner() {
-    return this.getOfflineSignerDirect();
+  getOfflineSigner(chainId) {
+    return this.getOfflineSignerDirect(chainId);
   }
 
-  getOfflineSignerDirect() {
+  getOfflineSignerDirect(chainId) {
+    this.assertChain(chainId);
     const { signer } = getKeystoreSigner();
     if (!signer) throw new Error(KEYSTORE_LOCKED_MESSAGE);
     return signer;
@@ -104,7 +173,7 @@ export class KeystoreWallet extends MainWalletBase {
   async initClient() {
     this.initingClient();
     try {
-      this.initClientDone(new KeystoreClient());
+      this.initClientDone(new KeystoreClient(resolveAssetmantleChainId(this)));
     } catch (error) {
       this.initClientError(error);
     }

--- a/lib/keystore/keystoreWallet.js
+++ b/lib/keystore/keystoreWallet.js
@@ -1,0 +1,130 @@
+/**
+ * KeystoreWallet — a cosmos-kit software (non-extension) wallet adapter that
+ * exposes the in-memory DirectSecp256k1HdWallet held by keystoreStore to the
+ * app's EXISTING cosmos-kit signing paths, with no browser extension involved
+ * and no edit to data/txApi.js.
+ *
+ * ── SPIKE FINDINGS (read against the installed node_modules, Step 1) ──────────
+ * Versions: @cosmos-kit/core 1.0.11, @cosmos-kit/keplr 0.32.28,
+ *           @cosmos-kit/react 1.0.14. (Packages ship CommonJS under `main/`,
+ *           not `cjs/`; base classes live in core/main/bases/.)
+ *
+ * A `wallets` array element passed to <ChainProvider wallets={[...]}> is a
+ * MainWalletBase INSTANCE. Proof: @cosmos-kit/keplr's export is literally
+ *   `wallets = [ new KeplrExtensionWallet(keplrExtensionInfo, preferredEndpoints) ]`
+ * (keplr-extension/main/keplr.js). ChainProvider calls setChains() on each
+ * wallet, which builds one ChainWalletBase per chain via `new this.ChainWallet`
+ * (core/main/bases/main-wallet.js).
+ *
+ * The MINIMAL surface a software wallet must implement:
+ *   1. A MainWalletBase subclass with async initClient() that calls
+ *      this.initClientDone(<client>). `client` is just read back via the
+ *      WalletBase `client` getter (clientMutable.data) — no window/extension
+ *      probe is required (core/main/bases/wallet.js).
+ *   2. A ChainWalletBase subclass — can be EMPTY; ChainKeplrExtension is empty.
+ *      ChainWalletBase already implements connect()/update(), initOfflineSigner()
+ *      and getSigningStargateClient() against `this.client`.
+ *   3. The `client` object, whose methods the base classes call:
+ *        • getAccount(chainId) -> { name, address, algo, pubkey }
+ *            called by ChainWalletBase.update() on connect(); only .address and
+ *            .name are consumed for setData (chain-wallet.js update()).
+ *        • getOfflineSigner(chainId) -> OfflineDirectSigner
+ *            called by ChainWalletBase.initOfflineSigner(), which
+ *            getSigningStargateClient() runs before
+ *            SigningStargateClient.connectWithSigner(rpc, offlineSigner).
+ *        • getOfflineSignerDirect(chainId) -> OfflineDirectSigner
+ *            surfaced by useChain().getOfflineSignerDirect (react/main/hooks.js).
+ *        • connect(chainId, isMobile) — OPTIONAL (invoked with ?.); no-op here.
+ *
+ * Delegation proof (react/main/hooks.js `useChain`):
+ *   getSigningStargateClient() -> current.getSigningStargateClient()  [ChainWalletBase]
+ *   getOfflineSigner(chainId)  -> current.client.getOfflineSigner(chainId)
+ * So data/txApi.js's `getSigningStargateClient()` reaches
+ * SigningStargateClient.connectWithSigner(rpc, <our in-memory signer>) unchanged.
+ *
+ * NOT required for a software signer (all optional or extension/wallet-connect
+ * only): the event emitter, session, addChain, sendTx, signAmino/signDirect.
+ * Amino signing is intentionally unsupported — DirectSecp256k1HdWallet is
+ * direct-only and the mantle tx paths sign via getSigningStargateClient (direct).
+ * Conclusion: tractable with a ~1-method client and two thin subclasses.
+ */
+
+import { MainWalletBase, ChainWalletBase } from "@cosmos-kit/core";
+import { getKeystoreSigner } from "./keystoreStore";
+
+const KEYSTORE_LOCKED_MESSAGE =
+  "Keystore is locked. Unlock your keystore account before signing.";
+
+// The wallet client: bridges keystoreStore's in-memory signer into the shape
+// the cosmos-kit base classes call. chainId args are part of the interface but
+// a single-key keystore serves one derived account regardless of chain, so they
+// are ignored.
+export class KeystoreClient {
+  async connect() {
+    // no-op: the signer is already in memory once the user unlocks the keystore.
+  }
+
+  async getAccount() {
+    const { signer } = getKeystoreSigner();
+    if (!signer) throw new Error(KEYSTORE_LOCKED_MESSAGE);
+    const [account] = await signer.getAccounts();
+    return {
+      name: "Keystore",
+      address: account.address,
+      algo: account.algo,
+      pubkey: account.pubkey,
+    };
+  }
+
+  getOfflineSigner() {
+    return this.getOfflineSignerDirect();
+  }
+
+  getOfflineSignerDirect() {
+    const { signer } = getKeystoreSigner();
+    if (!signer) throw new Error(KEYSTORE_LOCKED_MESSAGE);
+    return signer;
+  }
+
+  getOfflineSignerAmino() {
+    throw new Error(
+      "Amino signing is not supported by the keystore wallet; use direct signing."
+    );
+  }
+}
+
+// Empty subclass: ChainWalletBase already does everything against `this.client`.
+export class ChainKeystore extends ChainWalletBase {}
+
+export class KeystoreWallet extends MainWalletBase {
+  constructor(walletInfo) {
+    super(walletInfo, ChainKeystore);
+  }
+
+  async initClient() {
+    this.initingClient();
+    try {
+      this.initClientDone(new KeystoreClient());
+    } catch (error) {
+      this.initClientError(error);
+    }
+  }
+}
+
+// Registry entry (walletInfo). `mode` only needs to be anything other than
+// "wallet-connect" (WalletBase.connect branches on that); no real extension is
+// probed because initClient always yields our in-memory client.
+export const keystoreWalletInfo = {
+  name: "keystore-wallet",
+  prettyName: "Keystore",
+  mode: "extension",
+  mobileDisabled: false,
+  rejectMessage: { source: "Request rejected" },
+  // inline key glyph so the wallet list never renders a broken image (no fetch)
+  logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0iI2Y0YjczMSI+PHBhdGggZD0iTTEyLjY1IDEwQTUuOTkgNS45OSAwIDAgMCA3IDZhNiA2IDAgMSAwIDUuNjUgOEgxN3Y0aDR2LTRoMnYtNGgtMTAuMzV6TTcgMTZhMiAyIDAgMSAxIDAtNCAyIDIgMCAwIDEgMCA0eiIvPjwvc3ZnPg==",
+  downloads: [],
+};
+
+// cosmos-kit consumes a module-level singleton array (mirrors @cosmos-kit/keplr).
+export const keystoreWallet = new KeystoreWallet(keystoreWalletInfo);
+export const wallets = [keystoreWallet];

--- a/lib/keystore/legacyV1.js
+++ b/lib/keystore/legacyV1.js
@@ -1,0 +1,32 @@
+import { hexToBytes, bytesToHex } from "./hex";
+
+// READ-ONLY reproduction of walletOld's createKeyStore format. We decrypt V1
+// files; we never write this format (its AES key is stored in the file).
+export async function decryptLegacyV1(fileJson, password) {
+  const { hashpwd, iv, salt, crypted } = fileJson || {};
+  if (!hashpwd || !iv || !salt || !crypted)
+    return { error: "Not a valid V1 keystore file." };
+  const digest = await crypto.subtle.digest(
+    "SHA-512",
+    new TextEncoder().encode(password)
+  );
+  if (bytesToHex(new Uint8Array(digest)) !== hashpwd)
+    return { error: "Incorrect password." };
+  try {
+    const key = await crypto.subtle.importKey(
+      "raw",
+      hexToBytes(salt),
+      { name: "AES-CBC" },
+      false,
+      ["decrypt"]
+    );
+    const plain = await crypto.subtle.decrypt(
+      { name: "AES-CBC", iv: hexToBytes(iv) },
+      key,
+      hexToBytes(crypted)
+    );
+    return { mnemonic: new TextDecoder().decode(plain) };
+  } catch {
+    return { error: "Failed to decrypt keystore." };
+  }
+}

--- a/lib/keystore/modern.js
+++ b/lib/keystore/modern.js
@@ -1,0 +1,18 @@
+import { DirectSecp256k1HdWallet } from "@cosmjs/proto-signing";
+import { stringToPath } from "@cosmjs/crypto";
+
+// coin type 118, verified vs V1 - must stay identical to account.js (HD path
+// change breaks migration between the two).
+const HD = [stringToPath("m/44'/118'/0'/0/0")];
+
+export async function exportModern(mnemonic, password) {
+  const wallet = await DirectSecp256k1HdWallet.fromMnemonic(mnemonic, {
+    prefix: "mantle",
+    hdPaths: HD,
+  });
+  return wallet.serialize(password); // Argon2id + XChaCha20-Poly1305 JSON string
+}
+
+export async function importModern(serialization, password) {
+  return DirectSecp256k1HdWallet.deserialize(serialization, password);
+}

--- a/lib/keystore/passkey.js
+++ b/lib/keystore/passkey.js
@@ -158,6 +158,7 @@ export async function enrollPasskey({ rpId, rpName, userId, userName }) {
         displayName: userName,
       },
       pubKeyCredParams: [{ type: "public-key", alg: -7 }],
+      authenticatorSelection: { userVerification: "required" },
       extensions: { prf: {} },
     },
   });
@@ -167,6 +168,7 @@ export async function enrollPasskey({ rpId, rpName, userId, userName }) {
       challenge: randomBytes(32),
       allowCredentials: [{ id: credential.rawId, type: "public-key" }],
       extensions: { prf: { eval: { first: prfSaltBytes } } },
+      userVerification: "required",
     },
   });
 
@@ -185,6 +187,7 @@ export async function unlockPasskey({ credentialId, prfSalt }) {
         { id: base64urlToBytes(credentialId), type: "public-key" },
       ],
       extensions: { prf: { eval: { first: hexToBytes(prfSalt) } } },
+      userVerification: "required",
     },
   });
 

--- a/lib/keystore/passkey.js
+++ b/lib/keystore/passkey.js
@@ -114,7 +114,9 @@ function extractPrfSecretHex(credentialOrAssertion) {
   const results = credentialOrAssertion.getClientExtensionResults();
   const first =
     results && results.prf && results.prf.results && results.prf.results.first;
-  if (!first) throw new PrfUnsupportedError();
+  // A missing OR empty PRF result must fail like an unsupported authenticator:
+  // an empty secret would silently become an empty keystore password.
+  if (!first || first.byteLength === 0) throw new PrfUnsupportedError();
   return bytesToHex(new Uint8Array(first));
 }
 

--- a/lib/keystore/passkey.js
+++ b/lib/keystore/passkey.js
@@ -1,0 +1,190 @@
+// SPIKE - WebAuthn PRF request/response shapes (Task 4: passkey-as-unlock).
+//
+// Passkeys are P-256 and cannot sign Cosmos (secp256k1) transactions, so this
+// module never uses a passkey as a signing key. It uses the WebAuthn PRF
+// extension purely to derive a stable 32-byte secret per authenticator tap,
+// and that secret (hex-encoded) is fed to the existing modern keystore
+// (./modern.js exportModern/importModern) as an ordinary password. No new
+// crypto primitive is introduced here.
+//
+// Confirmed against the WebAuthn Level 3 spec's `prf` extension and the
+// shape this module's own tests mock:
+//
+//   1. Enrollment calls `navigator.credentials.create({ publicKey: { ...,
+//      extensions: { prf: {} } } })`. The created credential's own
+//      `getClientExtensionResults().prf` (when present) only reports
+//      capability (`{ enabled: true }`) at this stage - `create()` never
+//      returns PRF *output* bytes, only whether the authenticator supports
+//      the extension.
+//   2. A PRF secret is pulled by immediately following up with
+//      `navigator.credentials.get({ publicKey: { ...,
+//      allowCredentials: [{ id: <credential.rawId>, type: "public-key" }],
+//      extensions: { prf: { eval: { first: <32-byte salt> } } } } })`.
+//   3. The secret lands at
+//      `assertion.getClientExtensionResults().prf.results.first` as an
+//      ArrayBuffer (32 bytes for a SHA-256-based authenticator PRF). If
+//      `.prf` or `.prf.results.first` is missing, the authenticator/browser
+//      does not support PRF and this module throws `PrfUnsupportedError`
+//      rather than silently falling back to a weaker unlock path.
+//   4. Unlocking later (`unlockPasskey`) re-runs step 2 only, keyed by the
+//      *same* salt used at enrollment - the PRF output is deterministic per
+//      (credential, salt) pair, which is what lets it stand in for a stable
+//      keystore password across sessions.
+//
+// Encoding notes:
+//   - `credentialId` is returned/consumed as base64url (of `rawId`'s raw
+//     bytes). This repo's `hexToBytes`/`bytesToHex` (./hex.js) are reused for
+//     the PRF salt/secret, but WebAuthn credential IDs are conventionally
+//     base64url (what `PublicKeyCredential.id` gives back in a browser), so
+//     small local base64url helpers are used instead of overloading hex for
+//     both. They're implemented with `atob`/`btoa` (standard Web APIs,
+//     present in every browser and in jsdom) rather than Node's `Buffer`,
+//     since this module ships to the browser and this repo's webpack config
+//     has no `Buffer` polyfill for client bundles (see ../legacyV1.js, which
+//     avoids `Buffer` in browser-facing keystore code for the same reason).
+//   - `user.id` in the `create()` call must be a BufferSource per spec; this
+//     module accepts `userId` as a string (a stable local user/account
+//     identifier) and encodes it with `TextEncoder` - pass raw bytes
+//     directly if the caller already has them.
+//   - `challenge` is generated locally via `crypto.getRandomValues` rather
+//     than sourced from/verified by a server: this passkey is used purely as
+//     a local UNLOCK secret (PRF output -> keystore password), not as a
+//     server-verified login assertion, so there is no relying-party backend
+//     to source or check the challenge/attestation against. Wiring this into
+//     a real server-verified WebAuthn login later must source the challenge
+//     from that server instead.
+//   - `pubKeyCredParams` requests alg -7 (ES256 / P-256), the one every
+//     platform authenticator supports; it is never used to sign anything
+//     here (see above), only to satisfy `create()`'s required shape.
+//
+// E2E note (manual/CI-optional, not part of this unit suite): a documented
+// CDP virtual-authenticator flow - `CDPSession.send("WebAuthn.enable")` then
+// `addVirtualAuthenticator({ protocol: "ctap2", transport: "internal",
+// hasResidentKey: true, hasUserVerification: true, hasPrf: true,
+// isUserVerified: true })` via Playwright - driving enroll -> persist ->
+// reload -> unlock against a *real* (virtual) authenticator implementation,
+// is the next validation layer above this mocked unit suite. Real Touch ID /
+// platform-authenticator behavior is a separate manual check; neither this
+// module nor its tests can substitute for either.
+
+import { bytesToHex, hexToBytes } from "./hex";
+
+export class PrfUnsupportedError extends Error {
+  constructor(
+    message = "This authenticator/browser did not return a PRF secret."
+  ) {
+    super(message);
+    this.name = "PrfUnsupportedError";
+  }
+}
+
+function randomBytes(length) {
+  return crypto.getRandomValues(new Uint8Array(length));
+}
+
+function toBufferSource(value) {
+  return typeof value === "string" ? new TextEncoder().encode(value) : value;
+}
+
+// base64url (RFC 4648 section 5) via atob/btoa - see "Encoding notes" above
+// for why this avoids Node's Buffer.
+function bytesToBase64url(bytes) {
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++)
+    binary += String.fromCharCode(bytes[i]);
+  return btoa(binary)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function base64urlToBytes(value) {
+  const base64 = value.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = base64 + "=".repeat((4 - (base64.length % 4)) % 4);
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+// Shared by enrollPasskey/unlockPasskey: both read the PRF secret out of a
+// create()/get() result the same way and must fail the same way when the
+// authenticator didn't honor the extension.
+function extractPrfSecretHex(credentialOrAssertion) {
+  const results = credentialOrAssertion.getClientExtensionResults();
+  const first =
+    results && results.prf && results.prf.results && results.prf.results.first;
+  if (!first) throw new PrfUnsupportedError();
+  return bytesToHex(new Uint8Array(first));
+}
+
+export async function isPrfSupported() {
+  if (typeof navigator === "undefined" || !navigator.credentials) return false;
+  // Read via globalThis (always a recognized identifier) rather than the
+  // bare `PublicKeyCredential` global - this WebAuthn-specific global isn't
+  // in this project's configured eslint browser globals (unlike `crypto`/
+  // `navigator`/`TextEncoder`, which already are), and a property read never
+  // throws the way a bare undeclared-identifier reference would elsewhere.
+  const PublicKeyCredentialGlobal = globalThis.PublicKeyCredential;
+  if (typeof PublicKeyCredentialGlobal === "undefined") return false;
+  if (typeof PublicKeyCredentialGlobal.getClientCapabilities === "function") {
+    try {
+      const capabilities =
+        await PublicKeyCredentialGlobal.getClientCapabilities();
+      return !!capabilities["extension:prf"];
+    } catch {
+      return false;
+    }
+  }
+  // No capability-query API (older browsers): the base WebAuthn surface is
+  // present, but actual PRF support can only be confirmed by the create()/
+  // get() round-trip in enrollPasskey, which throws PrfUnsupportedError when
+  // the authenticator doesn't honor the extension.
+  return true;
+}
+
+export async function enrollPasskey({ rpId, rpName, userId, userName }) {
+  const prfSaltBytes = randomBytes(32);
+
+  const credential = await navigator.credentials.create({
+    publicKey: {
+      challenge: randomBytes(32),
+      rp: { id: rpId, name: rpName },
+      user: {
+        id: toBufferSource(userId),
+        name: userName,
+        displayName: userName,
+      },
+      pubKeyCredParams: [{ type: "public-key", alg: -7 }],
+      extensions: { prf: {} },
+    },
+  });
+
+  const assertion = await navigator.credentials.get({
+    publicKey: {
+      challenge: randomBytes(32),
+      allowCredentials: [{ id: credential.rawId, type: "public-key" }],
+      extensions: { prf: { eval: { first: prfSaltBytes } } },
+    },
+  });
+
+  return {
+    credentialId: bytesToBase64url(new Uint8Array(credential.rawId)),
+    prfSalt: bytesToHex(prfSaltBytes),
+    prfSecretHex: extractPrfSecretHex(assertion),
+  };
+}
+
+export async function unlockPasskey({ credentialId, prfSalt }) {
+  const assertion = await navigator.credentials.get({
+    publicKey: {
+      challenge: randomBytes(32),
+      allowCredentials: [
+        { id: base64urlToBytes(credentialId), type: "public-key" },
+      ],
+      extensions: { prf: { eval: { first: hexToBytes(prfSalt) } } },
+    },
+  });
+
+  return extractPrfSecretHex(assertion);
+}

--- a/lib/keystore/persist.js
+++ b/lib/keystore/persist.js
@@ -1,0 +1,39 @@
+// Opt-in localStorage persistence for the passkey-unlock keystore handle.
+//
+// This is the ONLY place a keystore secret is allowed to touch disk, and
+// even then never in the clear: the three fields below are a WebAuthn
+// credential handle, its PRF salt, and the MODERN (Argon2id +
+// XChaCha20-Poly1305 encrypted, see ./modern.js) blob. A raw key, mnemonic,
+// or the read-only legacy V1 shape must never reach this module - callers
+// only ever hand it what enrollPasskey()/exportModern() already produced.
+//
+// savePasskeyKeystore() allowlists exactly these three fields on the way in
+// (rather than validating-then-rejecting extras), so any extra property a
+// caller accidentally attaches - a mnemonic, a raw private key - is silently
+// dropped, never serialized to storage.
+const STORAGE_KEY = "am-keystore-passkey-v1";
+
+export function savePasskeyKeystore({ credentialId, prfSalt, modernBlob }) {
+  localStorage.setItem(
+    STORAGE_KEY,
+    JSON.stringify({ credentialId, prfSalt, modernBlob })
+  );
+}
+
+export function loadPasskeyKeystore() {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (!raw) return null;
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  const { credentialId, prfSalt, modernBlob } = parsed || {};
+  if (!credentialId || !prfSalt || !modernBlob) return null;
+  return { credentialId, prfSalt, modernBlob };
+}
+
+export function clearPasskeyKeystore() {
+  localStorage.removeItem(STORAGE_KEY);
+}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@chakra-ui/react": "2.3.7",
     "@cosmjs/amino": "^0.29.3",
     "@cosmjs/cosmwasm-stargate": "0.29.3",
+    "@cosmjs/crypto": "^0.29.3",
     "@cosmjs/encoding": "^0.29.5",
     "@cosmjs/proto-signing": "^0.29.3",
     "@cosmjs/stargate": "^0.29.3",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "lint": "next lint --fix --dir .",
     "prepare": "husky install",
     "format": "prettier --write .",
-    "pre-commit": "lint-staged"
+    "pre-commit": "lint-staged",
+    "test": "jest",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@chakra-ui/react": "2.3.7",
@@ -45,6 +47,7 @@
     "@nivo/sunburst": "^0.80.0",
     "@osmonauts/lcd": "^0.8.0",
     "@splidejs/react-splide": "^0.7.12",
+    "@wagmi/core": "0.9.5",
     "@web3modal/ethereum": "^2.1.1",
     "@web3modal/react": "^2.1.1",
     "bignumber.js": "^9.1.1",
@@ -52,8 +55,11 @@
     "chain-registry": "^1.7.0",
     "ethers": "^5.7.2",
     "framer-motion": "7.6.5",
+    "long": "^4.0.0",
     "next": "12.3.7",
     "osmojs": "^16.14.0",
+    "protobufjs": "^7.6.3",
+    "qrcode.react": "^3.1.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-icons": "4.6.0",
@@ -63,13 +69,11 @@
     "sass": "^1.56.1",
     "slick-carousel": "^1.8.1",
     "swr": "^1.3.0",
-    "wagmi": "^0.11.5",
-    "qrcode.react": "^3.1.0",
-    "@wagmi/core": "0.9.5",
-    "protobufjs": "^7.6.3",
-    "long": "^4.0.0"
+    "wagmi": "^0.11.5"
   },
   "devDependencies": {
+    "@osmonauts/telescope": "^0.75.0",
+    "@types/minimatch": "^5.1.2",
     "@types/node": "18.11.9",
     "@types/react": "18.0.25",
     "@types/react-dom": "18.0.8",
@@ -79,10 +83,10 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-unused-imports": "^2.0.0",
     "husky": "^8.0.3",
-    "typescript": "4.8.4",
+    "jest": "^30.4.2",
+    "jest-environment-jsdom": "^30.4.1",
     "lint-staged": "^16.2.7",
-    "@osmonauts/telescope": "^0.75.0",
-    "@types/minimatch": "^5.1.2"
+    "typescript": "4.8.4"
   },
   "resolutions": {
     "axios": "^1.16.0",

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -4,6 +4,7 @@ import { wallets as vectisWallets } from "@cosmos-kit/vectis";
 import { wallets as keplrWallets } from "@cosmos-kit/keplr";
 import { wallets as cosmostationWallets } from "@cosmos-kit/cosmostation";
 import { ChainProvider } from "@cosmos-kit/react";
+import { wallets as keystoreWallets } from "../lib/keystore/keystoreWallet";
 import { Web3Modal } from "@web3modal/react";
 import { assets, chains } from "chain-registry";
 import Head from "next/head";
@@ -116,6 +117,7 @@ function CreateCosmosApp({ Component, pageProps }) {
               ...leapWallets,
               cosmostationWallets[0],
               ...vectisWallets,
+              ...keystoreWallets,
             ]}
             signerOptions={signerOptions}
             sessionOptions={sessionOptions}

--- a/views/ConnectModal/ConnectModal.jsx
+++ b/views/ConnectModal/ConnectModal.jsx
@@ -1,9 +1,18 @@
 import Link from "next/link";
-import React from "react";
+import React, { useState } from "react";
 import { ConnectOptionObject, mantleWalletV1URL } from "../../data";
 import { cleanString } from "../../lib";
+import KeystoreConnect from "./KeystoreConnect";
+
+// Stable registered name of lib/keystore/keystoreWallet.js's cosmos-kit
+// adapter (see keystoreWalletInfo.name there). Matched on this rather than
+// the display-only walletPrettyName so it can't collide with a future
+// wallet that happens to share the "Keystore" label.
+const KEYSTORE_WALLET_NAME = "keystore-wallet";
 
 const ConnectModal = ({ setOpen, walletRepo }) => {
+  const [keystoreOpen, setKeystoreOpen] = useState(false);
+
   function handleCloseModal(e) {
     e.preventDefault();
     setOpen(false);
@@ -17,87 +26,129 @@ const ConnectModal = ({ setOpen, walletRepo }) => {
         style={{ maxWidth: "min(100%, 600px)" }}
       >
         <div className="modal-content">
-          <div className="bg-gray-800 p-4 rounded-4 w-100 my-auto">
-            <div className="d-flex align-items-center justify-content-between ">
-              <h1 className="body1 text-primary">Connect Wallet</h1>
-              <button
-                className="btn text-primary body1"
-                onClick={handleCloseModal}
-                data-bs-dismiss="modal"
-                aria-label="Close"
-              >
-                <i className="bi bi-x-lg" />
-              </button>
-            </div>
-            <div className="text-white body2 my-1 text-center">
-              Connect With
-            </div>
-            <p className="text-white-200 caption my-1 text-center">
-              Connect your wallet using any of the options below
-            </p>
-            <div className="d-flex flex-column gap-3 mt-5">
-              <h2 className="caption text-white">
-                Connect with existing Wallet
-              </h2>
-              <div className="d-flex gap-2 flex-wrap">
-                {walletRepo?.wallets.map(
-                  (
-                    { walletPrettyName, connect, isError, isWalletConnected },
-                    index
-                  ) => (
-                    <button
-                      className="d-flex align-items-center gap-2 button-secondary py-2 px-3 rounded-2"
-                      key={index}
-                      data-bs-dismiss="modal"
-                      aria-label="Close"
-                      onClick={async () => {
-                        await connect();
-                        setOpen(false);
-                      }}
-                    >
-                      <div
-                        className="position-relative"
-                        style={{ width: "25px", aspectRatio: "1/1" }}
-                      >
-                        <img
-                          src={
-                            ConnectOptionObject[cleanString(walletPrettyName)]
-                              ?.icon
-                          }
-                          alt={walletPrettyName}
-                        />
-                      </div>
-                      {walletPrettyName === "Cosmos Metamask Extension"
-                        ? ConnectOptionObject[cleanString(walletPrettyName)]
-                            ?.name
-                        : walletPrettyName}
-                    </button>
-                  )
-                )}
+          {keystoreOpen ? (
+            <KeystoreConnect
+              walletRepo={walletRepo}
+              onBack={() => setKeystoreOpen(false)}
+              onClose={() => {
+                setKeystoreOpen(false);
+                setOpen(false);
+              }}
+            />
+          ) : (
+            <div className="bg-gray-800 p-4 rounded-4 w-100 my-auto">
+              <div className="d-flex align-items-center justify-content-between ">
+                <h1 className="body1 text-primary">Connect Wallet</h1>
+                <button
+                  className="btn text-primary body1"
+                  onClick={handleCloseModal}
+                  data-bs-dismiss="modal"
+                  aria-label="Close"
+                >
+                  <i className="bi bi-x-lg" />
+                </button>
               </div>
-            </div>
+              <div className="text-white body2 my-1 text-center">
+                Connect With
+              </div>
+              <p className="text-white-200 caption my-1 text-center">
+                Connect your wallet using any of the options below
+              </p>
+              <div className="d-flex flex-column gap-3 mt-5">
+                <h2 className="caption text-white">
+                  Connect with existing Wallet
+                </h2>
+                <div className="d-flex gap-2 flex-wrap">
+                  {walletRepo?.wallets
+                    .filter(
+                      ({ walletName }) => walletName !== KEYSTORE_WALLET_NAME
+                    )
+                    .map(
+                      (
+                        {
+                          walletPrettyName,
+                          connect,
+                          isError,
+                          isWalletConnected,
+                        },
+                        index
+                      ) => (
+                        <button
+                          className="d-flex align-items-center gap-2 button-secondary py-2 px-3 rounded-2"
+                          key={index}
+                          data-bs-dismiss="modal"
+                          aria-label="Close"
+                          onClick={async () => {
+                            await connect();
+                            setOpen(false);
+                          }}
+                        >
+                          <div
+                            className="position-relative"
+                            style={{ width: "25px", aspectRatio: "1/1" }}
+                          >
+                            <img
+                              src={
+                                ConnectOptionObject[
+                                  cleanString(walletPrettyName)
+                                ]?.icon
+                              }
+                              alt={walletPrettyName}
+                            />
+                          </div>
+                          {walletPrettyName === "Cosmos Metamask Extension"
+                            ? ConnectOptionObject[cleanString(walletPrettyName)]
+                                ?.name
+                            : walletPrettyName}
+                        </button>
+                      )
+                    )}
+                </div>
+              </div>
 
-            <div className="d-flex flex-column gap-3 mt-5">
-              <h2 className="caption text-white">
-                Go to Old Wallet for Keystore & Ledger
-              </h2>
-              <div className="d-flex gap-2 flex-wrap">
-                <Link href={mantleWalletV1URL}>
-                  <a>
-                    <button className="d-flex align-items-center gap-2 button-secondary py-2 px-3 rounded-2">
-                      <div
-                        className="position-relative"
-                        style={{ width: "25px", aspectRatio: "1/1" }}
-                      >
-                        <img src={"/favicon.png"} alt={"v1_wallet"} />
-                      </div>
-                      MantleWallet V1 (Old)
-                    </button>
-                  </a>
-                </Link>
+              <div className="d-flex flex-column gap-3 mt-5">
+                <h2 className="caption text-white">Connect with Keystore</h2>
+                <div className="d-flex gap-2 flex-wrap">
+                  <button
+                    className="d-flex align-items-center gap-2 button-secondary py-2 px-3 rounded-2"
+                    onClick={() => setKeystoreOpen(true)}
+                  >
+                    <div
+                      className="position-relative"
+                      style={{ width: "25px", aspectRatio: "1/1" }}
+                    >
+                      <img
+                        src={ConnectOptionObject.keystore.icon}
+                        alt={ConnectOptionObject.keystore.name}
+                      />
+                    </div>
+                    {ConnectOptionObject.keystore.name}
+                  </button>
+                </div>
+              </div>
+
+              <div className="d-flex flex-column gap-3 mt-5">
+                <h2 className="caption text-white">
+                  Go to Old Wallet for Ledger
+                </h2>
+                <div className="d-flex gap-2 flex-wrap">
+                  <Link href={mantleWalletV1URL}>
+                    <a>
+                      <button className="d-flex align-items-center gap-2 button-secondary py-2 px-3 rounded-2">
+                        <div
+                          className="position-relative"
+                          style={{ width: "25px", aspectRatio: "1/1" }}
+                        >
+                          <img src={"/favicon.png"} alt={"v1_wallet"} />
+                        </div>
+                        MantleWallet V1 (Old)
+                      </button>
+                    </a>
+                  </Link>
+                </div>
               </div>
             </div>
-          </div>
+          )}
         </div>
       </div>
     </div>

--- a/views/ConnectModal/KeystoreConnect.js
+++ b/views/ConnectModal/KeystoreConnect.js
@@ -124,11 +124,17 @@ export default function KeystoreConnect({ walletRepo, onBack, onClose }) {
   // registered keystore wallet. Returns an error string on failure (never
   // throws), and always clears the in-memory signer again on failure so a
   // half-connected keystore never lingers.
+  //
+  // walletRepo.getWallet(name) is cosmos-kit's own lookup (WalletRepo.getWallet
+  // in @cosmos-kit/core, `this.wallets.find(w => w.walletName === name)`) -
+  // used here instead of a hand-rolled .find() for the same result. Its
+  // sibling walletRepo.connect(name) was deliberately NOT used: it also
+  // calls openView() and forwards the chain's configured sessionOptions,
+  // which would diverge from how every other wallet button in this same
+  // file connects (a bare wallet.connect() with no args).
   async function connectKeystoreWallet(signer, addr) {
     setKeystoreSigner(signer, addr);
-    const wallet = walletRepo?.wallets.find(
-      (w) => w.walletName === KEYSTORE_WALLET_NAME
-    );
+    const wallet = walletRepo?.getWallet(KEYSTORE_WALLET_NAME);
     if (!wallet) {
       clearKeystoreSigner();
       return "Keystore wallet is not registered. Refresh the page and try again.";

--- a/views/ConnectModal/KeystoreConnect.js
+++ b/views/ConnectModal/KeystoreConnect.js
@@ -184,9 +184,16 @@ export default function KeystoreConnect({ walletRepo, onBack, onClose }) {
           setPasswordError(result.error);
           return;
         }
-        const { signer, address: addr } = await mnemonicToSigner(
-          result.mnemonic
-        );
+        // AES-CBC has no integrity check, so a file with a matching password
+        // hash but corrupted ciphertext decrypts to a garbage mnemonic that
+        // fails bip39 validation here. Surface it instead of throwing silently.
+        let signer, addr;
+        try {
+          ({ signer, address: addr } = await mnemonicToSigner(result.mnemonic));
+        } catch {
+          setPasswordError("Could not read this keystore file.");
+          return;
+        }
         const err = await connectKeystoreWallet(signer, addr);
         if (err) {
           setPasswordError(err);

--- a/views/ConnectModal/KeystoreConnect.js
+++ b/views/ConnectModal/KeystoreConnect.js
@@ -45,10 +45,20 @@ function detectKeystoreShape(json) {
 // ConnectModal.jsx in place of the old "Go to Old Wallet for Keystore" link.
 // Steps: menu (upload or unlock-with-passkey) -> upload -> password ->
 // [legacy only] forced upgrade-download -> success (download / enable
-// passkey). Every async primitive here is a prior, unit-tested module
-// (legacyV1/modern/account/keystoreStore/passkey/persist/download); this
-// component only sequences them and is build-verified - the interactive
-// walk-through is the manual browser pass in Task 6.
+// passkey, both via an exportPassword sub-step). Every async primitive here
+// is a prior, unit-tested module (legacyV1/modern/account/keystoreStore/
+// passkey/persist/download); this component only sequences them and is
+// build-verified - the interactive walk-through is the manual browser pass
+// in Task 6.
+//
+// Security-review hardening: the legacy mnemonic and the password that
+// unlocked it live only in refs, never React state, and are cleared the
+// moment the flow leaves the legacy-upgrade step (M1 - keeps them out of the
+// React fiber). Every user-facing export ("Download keystore", the forced
+// backup before enabling a passkey) is encrypted with a password freshly
+// typed in the exportPassword step, never the secret that unlocked this
+// session (M2) - after a passkey unlock that secret is a device-bound PRF
+// output nobody can type back in to decrypt a download elsewhere.
 export default function KeystoreConnect({ walletRepo, onBack, onClose }) {
   const [step, setStep] = useState("menu");
   const [busy, setBusy] = useState(false);
@@ -64,8 +74,12 @@ export default function KeystoreConnect({ walletRepo, onBack, onClose }) {
   const [password, setPassword] = useState("");
   const [passwordError, setPasswordError] = useState(null);
 
-  const [legacyMnemonic, setLegacyMnemonic] = useState(null);
-  const [unlockSecret, setUnlockSecret] = useState(null);
+  // Legacy mnemonic + the password that unlocked it: refs, not state, so
+  // they never enter the React fiber (M1). Only ever populated on the legacy
+  // path, only ever read for the forced upgrade download, and cleared the
+  // moment that step is left (see the "Continue" handler below).
+  const legacyMnemonicRef = useRef(null);
+  const legacyPasswordRef = useRef(null);
   const [upgradeError, setUpgradeError] = useState(null);
   const upgradeBlobRef = useRef(null);
   const upgradeTriggered = useRef(false);
@@ -73,7 +87,14 @@ export default function KeystoreConnect({ walletRepo, onBack, onClose }) {
   const [address, setAddress] = useState(null);
   const [actionError, setActionError] = useState(null);
   const [actionMessage, setActionMessage] = useState(null);
-  const [passkeyBusy, setPasskeyBusy] = useState(false);
+
+  // "Download keystore" / "Enable passkey unlock" both route through this
+  // sub-step so the export is always encrypted with a password the user just
+  // typed (M2), never the secret that unlocked the session. pendingExportActionRef
+  // records which of the two actions is in flight; it never needs to trigger
+  // a re-render so it's a ref rather than state.
+  const [exportPassword, setExportPassword] = useState("");
+  const pendingExportActionRef = useRef(null); // "download" | "enablePasskey"
 
   // Passkey availability + a previously-enrolled record (if any) only need
   // checking once per mount of this sub-flow.
@@ -91,12 +112,18 @@ export default function KeystoreConnect({ walletRepo, onBack, onClose }) {
   // "force" the upgrade download: fire it the moment the step is entered,
   // not gated behind an extra click. upgradeTriggered guards against a
   // second auto-fire (e.g. React StrictMode's double-invoke in dev).
+  // legacyMnemonicRef/legacyPasswordRef are refs (M1), so they're read
+  // directly rather than listed as effect deps - mutating a ref never needs
+  // to re-run this effect, only `step` changing does.
   useEffect(() => {
     if (step !== "legacyUpgrade" || upgradeTriggered.current) return;
     upgradeTriggered.current = true;
     (async () => {
       try {
-        const blob = await exportModern(legacyMnemonic, unlockSecret);
+        const blob = await exportModern(
+          legacyMnemonicRef.current,
+          legacyPasswordRef.current
+        );
         upgradeBlobRef.current = blob;
         downloadModernKeystore(blob, BACKUP_FILENAME);
       } catch {
@@ -105,7 +132,7 @@ export default function KeystoreConnect({ walletRepo, onBack, onClose }) {
         );
       }
     })();
-  }, [step, legacyMnemonic, unlockSecret]);
+  }, [step]);
 
   function handleBack() {
     if (step === "menu") {
@@ -199,8 +226,8 @@ export default function KeystoreConnect({ walletRepo, onBack, onClose }) {
           setPasswordError(err);
           return;
         }
-        setLegacyMnemonic(result.mnemonic);
-        setUnlockSecret(password);
+        legacyMnemonicRef.current = result.mnemonic;
+        legacyPasswordRef.current = password;
         setAddress(addr);
         setStep("legacyUpgrade");
       } else {
@@ -217,7 +244,6 @@ export default function KeystoreConnect({ walletRepo, onBack, onClose }) {
           setPasswordError(err);
           return;
         }
-        setUnlockSecret(password);
         setAddress(account.address);
         setStep("success");
       }
@@ -243,7 +269,9 @@ export default function KeystoreConnect({ walletRepo, onBack, onClose }) {
         setMenuError(err);
         return;
       }
-      setUnlockSecret(prfSecretHex);
+      // prfSecretHex is device-bound and deliberately not retained anywhere
+      // (M2): a passkey-unlocked session's user-facing exports always prompt
+      // for a fresh password instead (see the exportPassword step).
       setAddress(account.address);
       setStep("success");
     } catch (error) {
@@ -261,7 +289,10 @@ export default function KeystoreConnect({ walletRepo, onBack, onClose }) {
     try {
       let blob = upgradeBlobRef.current;
       if (!blob) {
-        blob = await exportModern(legacyMnemonic, unlockSecret);
+        blob = await exportModern(
+          legacyMnemonicRef.current,
+          legacyPasswordRef.current
+        );
         upgradeBlobRef.current = blob;
       }
       downloadModernKeystore(blob, BACKUP_FILENAME);
@@ -273,7 +304,15 @@ export default function KeystoreConnect({ walletRepo, onBack, onClose }) {
     }
   }
 
-  async function handleDownloadKeystore() {
+  // Both actions below need a keystore export, and every user-facing export
+  // must be encrypted with a password the user freshly types (M2) - never
+  // the secret that unlocked this session, which after a passkey unlock is a
+  // device-bound PRF secret the user could never type back in on another
+  // device. These two handlers just record which action was requested and
+  // open that prompt; the real export happens in
+  // handleExportPasswordConfirm once the password is in.
+  function handleDownloadKeystore() {
+    if (busy) return;
     setActionError(null);
     setActionMessage(null);
     const { signer } = getKeystoreSigner();
@@ -281,54 +320,93 @@ export default function KeystoreConnect({ walletRepo, onBack, onClose }) {
       setActionError("Keystore is locked. Reconnect and try again.");
       return;
     }
-    try {
-      const blob = await signer.serialize(unlockSecret);
-      downloadModernKeystore(blob, BACKUP_FILENAME);
-      setActionMessage("Keystore file downloaded.");
-    } catch {
-      setActionError("Could not prepare the keystore file for download.");
-    }
+    pendingExportActionRef.current = "download";
+    setExportPassword("");
+    setStep("exportPassword");
   }
 
   // TODO(manual-verify Task 6): this calls the real, already-unit-tested
   // passkey.js/persist.js primitives end-to-end (enroll -> re-serialize ->
   // persist) rather than a fake handler, but the interactive Touch-ID/PRF
   // round trip itself can only be exercised in a real browser.
-  async function handleEnablePasskey() {
-    if (passkeyBusy) return;
+  function handleEnablePasskey() {
+    if (busy) return;
+    setActionError(null);
+    setActionMessage(null);
     const { signer } = getKeystoreSigner();
     if (!signer) {
       setActionError("Keystore is locked. Reconnect and try again.");
       return;
     }
-    setPasskeyBusy(true);
-    setActionError(null);
-    setActionMessage(null);
-    try {
-      // Force a backup download first: never let the account become
-      // solely reliant on this browser's localStorage + passkey.
-      const backupBlob = await signer.serialize(unlockSecret);
-      downloadModernKeystore(backupBlob, BACKUP_FILENAME);
+    pendingExportActionRef.current = "enablePasskey";
+    setExportPassword("");
+    setStep("exportPassword");
+  }
 
-      const { credentialId, prfSalt, prfSecretHex } = await enrollPasskey({
-        rpId: window.location.hostname,
-        rpName: "AssetMantle Wallet",
-        userId: address,
-        userName: address,
-      });
-      const modernBlob = await signer.serialize(prfSecretHex);
-      savePasskeyKeystore({ credentialId, prfSalt, modernBlob });
-      setActionMessage(
-        "Passkey unlock enabled for this browser. A backup keystore file was downloaded too - keep it somewhere safe."
-      );
+  function handleCancelExportPassword() {
+    setExportPassword("");
+    pendingExportActionRef.current = null;
+    setStep("success");
+  }
+
+  // Confirm handler for the exportPassword step: performs whichever action
+  // was requested (plain download, or the forced backup + enroll for
+  // passkey unlock), always encrypting with the password just typed here.
+  async function handleExportPasswordConfirm() {
+    if (busy || !exportPassword || exportPassword.length <= 8) return;
+    const action = pendingExportActionRef.current;
+    const { signer } = getKeystoreSigner();
+    if (!signer) {
+      setStep("success");
+      setActionError("Keystore is locked. Reconnect and try again.");
+      return;
+    }
+    setBusy(true);
+    try {
+      if (action === "download") {
+        const blob = await signer.serialize(exportPassword);
+        downloadModernKeystore(blob, BACKUP_FILENAME);
+        setActionMessage("Keystore file downloaded.");
+        setActionError(null);
+      } else if (action === "enablePasskey") {
+        // Force a backup download first: never let the account become
+        // solely reliant on this browser's localStorage + passkey.
+        const backupBlob = await signer.serialize(exportPassword);
+        downloadModernKeystore(backupBlob, BACKUP_FILENAME);
+
+        const { credentialId, prfSalt, prfSecretHex } = await enrollPasskey({
+          rpId: window.location.hostname,
+          rpName: "AssetMantle Wallet",
+          userId: address,
+          userName: address,
+        });
+        // Unlike the user-facing backup above, this blob is never shown to
+        // or typed by the user - it's persisted so unlockPasskey() can
+        // re-derive this same prfSecretHex from the same authenticator next
+        // time, so reusing it here (instead of exportPassword) is correct
+        // and not the M2 issue.
+        const modernBlob = await signer.serialize(prfSecretHex);
+        savePasskeyKeystore({ credentialId, prfSalt, modernBlob });
+        setActionMessage(
+          "Passkey unlock enabled for this browser. A backup keystore file was downloaded too - keep it somewhere safe."
+        );
+        setActionError(null);
+      }
+      setStep("success");
     } catch (error) {
+      setActionMessage(null);
       setActionError(
-        error instanceof PrfUnsupportedError
+        action === "enablePasskey" && error instanceof PrfUnsupportedError
           ? "This device/browser does not support passkey unlock (PRF). Use your password instead."
+          : action === "download"
+          ? "Could not prepare the keystore file for download."
           : "Could not enable passkey unlock."
       );
+      setStep("success");
     } finally {
-      setPasskeyBusy(false);
+      setBusy(false);
+      setExportPassword("");
+      pendingExportActionRef.current = null;
     }
   }
 
@@ -340,6 +418,8 @@ export default function KeystoreConnect({ walletRepo, onBack, onClose }) {
       ? "Enter Password"
       : step === "legacyUpgrade"
       ? "Upgrade Your Keystore"
+      : step === "exportPassword"
+      ? "Set Export Password"
       : step === "success"
       ? "Keystore Connected"
       : "Connect with Keystore";
@@ -489,7 +569,8 @@ export default function KeystoreConnect({ walletRepo, onBack, onClose }) {
               type="button"
               className="am-link ms-auto px-3"
               onClick={() => {
-                setLegacyMnemonic(null);
+                legacyMnemonicRef.current = null;
+                legacyPasswordRef.current = null;
                 setStep("success");
               }}
             >
@@ -497,6 +578,44 @@ export default function KeystoreConnect({ walletRepo, onBack, onClose }) {
             </button>
           </div>
         </div>
+      )}
+
+      {step === "exportPassword" && (
+        <>
+          <p className="text-white-200 caption my-1">
+            Choose a password to encrypt this keystore export. You&apos;ll need
+            to type this same password to unlock the downloaded file later - it
+            isn&apos;t saved anywhere.
+          </p>
+          <input
+            type="password"
+            className="am-input w-100 my-3 py-2 px-3 rounded-1 bg-t border-color-white"
+            placeholder="******"
+            value={exportPassword}
+            onChange={(e) => setExportPassword(e.target.value)}
+            onKeyDown={(e) =>
+              e.key === "Enter" && handleExportPasswordConfirm()
+            }
+          />
+          <div className="d-flex align-items-center justify-content-end gap-3 flex-wrap mt-3">
+            <button
+              type="button"
+              className="am-link px-3"
+              disabled={busy}
+              onClick={handleCancelExportPassword}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              className="button-primary caption py-2 px-5"
+              onClick={handleExportPasswordConfirm}
+              disabled={busy || !exportPassword || exportPassword.length <= 8}
+            >
+              {busy ? "Preparing..." : "Confirm"}
+            </button>
+          </div>
+        </>
       )}
 
       {step === "success" && (
@@ -525,10 +644,9 @@ export default function KeystoreConnect({ walletRepo, onBack, onClose }) {
               <button
                 type="button"
                 className="button-secondary py-2 px-4 rounded-2"
-                disabled={passkeyBusy}
                 onClick={handleEnablePasskey}
               >
-                {passkeyBusy ? "Enabling..." : "Enable passkey unlock"}
+                Enable passkey unlock
               </button>
             )}
             {actionError && <p className="text-error caption">{actionError}</p>}

--- a/views/ConnectModal/KeystoreConnect.js
+++ b/views/ConnectModal/KeystoreConnect.js
@@ -1,0 +1,541 @@
+import React, { useEffect, useRef, useState } from "react";
+import { shortenAddress } from "../../lib";
+import { decryptLegacyV1 } from "../../lib/keystore/legacyV1";
+import { exportModern, importModern } from "../../lib/keystore/modern";
+import { mnemonicToSigner } from "../../lib/keystore/account";
+import {
+  setKeystoreSigner,
+  getKeystoreSigner,
+  clearKeystoreSigner,
+} from "../../lib/keystore/keystoreStore";
+import {
+  isPrfSupported,
+  enrollPasskey,
+  unlockPasskey,
+  PrfUnsupportedError,
+} from "../../lib/keystore/passkey";
+import {
+  savePasskeyKeystore,
+  loadPasskeyKeystore,
+} from "../../lib/keystore/persist";
+import { downloadModernKeystore } from "../../lib/keystore/download";
+
+const KEYSTORE_WALLET_NAME = "keystore-wallet";
+const BACKUP_FILENAME = "assetmantle-keystore-modern.json";
+
+function readFileAsText(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result);
+    reader.onerror = () =>
+      reject(reader.error || new Error("Could not read file."));
+    reader.readAsText(file);
+  });
+}
+
+// legacy V1 files carry hashpwd+salt+crypted; the modern cosmjs export
+// carries type+kdf (see lib/keystore/legacyV1.js and modern.js).
+function detectKeystoreShape(json) {
+  if (json && json.hashpwd && json.salt && json.crypted) return "legacy";
+  if (json && json.type && json.kdf) return "modern";
+  return null;
+}
+
+// Real keystore connect/import/export/passkey sub-flow, opened from
+// ConnectModal.jsx in place of the old "Go to Old Wallet for Keystore" link.
+// Steps: menu (upload or unlock-with-passkey) -> upload -> password ->
+// [legacy only] forced upgrade-download -> success (download / enable
+// passkey). Every async primitive here is a prior, unit-tested module
+// (legacyV1/modern/account/keystoreStore/passkey/persist/download); this
+// component only sequences them and is build-verified - the interactive
+// walk-through is the manual browser pass in Task 6.
+export default function KeystoreConnect({ walletRepo, onBack, onClose }) {
+  const [step, setStep] = useState("menu");
+  const [busy, setBusy] = useState(false);
+  const [menuError, setMenuError] = useState(null);
+  const [passkeyAvailable, setPasskeyAvailable] = useState(false);
+  const [savedPasskey, setSavedPasskey] = useState(null);
+
+  const [fileText, setFileText] = useState(null);
+  const [fileJson, setFileJson] = useState(null);
+  const [shape, setShape] = useState(null);
+  const [uploadError, setUploadError] = useState(null);
+
+  const [password, setPassword] = useState("");
+  const [passwordError, setPasswordError] = useState(null);
+
+  const [legacyMnemonic, setLegacyMnemonic] = useState(null);
+  const [unlockSecret, setUnlockSecret] = useState(null);
+  const [upgradeError, setUpgradeError] = useState(null);
+  const upgradeBlobRef = useRef(null);
+  const upgradeTriggered = useRef(false);
+
+  const [address, setAddress] = useState(null);
+  const [actionError, setActionError] = useState(null);
+  const [actionMessage, setActionMessage] = useState(null);
+  const [passkeyBusy, setPasskeyBusy] = useState(false);
+
+  // Passkey availability + a previously-enrolled record (if any) only need
+  // checking once per mount of this sub-flow.
+  useEffect(() => {
+    let cancelled = false;
+    isPrfSupported().then((supported) => {
+      if (!cancelled) setPasskeyAvailable(supported);
+    });
+    setSavedPasskey(loadPasskeyKeystore());
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // "force" the upgrade download: fire it the moment the step is entered,
+  // not gated behind an extra click. upgradeTriggered guards against a
+  // second auto-fire (e.g. React StrictMode's double-invoke in dev).
+  useEffect(() => {
+    if (step !== "legacyUpgrade" || upgradeTriggered.current) return;
+    upgradeTriggered.current = true;
+    (async () => {
+      try {
+        const blob = await exportModern(legacyMnemonic, unlockSecret);
+        upgradeBlobRef.current = blob;
+        downloadModernKeystore(blob, BACKUP_FILENAME);
+      } catch {
+        setUpgradeError(
+          "Could not prepare the upgraded keystore file automatically. Use the button below to try again."
+        );
+      }
+    })();
+  }, [step, legacyMnemonic, unlockSecret]);
+
+  function handleBack() {
+    if (step === "menu") {
+      onBack();
+      return;
+    }
+    if (step === "upload" || step === "password") {
+      setStep("menu");
+      setUploadError(null);
+      setPasswordError(null);
+    }
+  }
+
+  // Shared by every unlock path (legacy, modern-file, passkey): sets the
+  // in-memory signer first, then drives the real cosmos-kit connect for the
+  // registered keystore wallet. Returns an error string on failure (never
+  // throws), and always clears the in-memory signer again on failure so a
+  // half-connected keystore never lingers.
+  async function connectKeystoreWallet(signer, addr) {
+    setKeystoreSigner(signer, addr);
+    const wallet = walletRepo?.wallets.find(
+      (w) => w.walletName === KEYSTORE_WALLET_NAME
+    );
+    if (!wallet) {
+      clearKeystoreSigner();
+      return "Keystore wallet is not registered. Refresh the page and try again.";
+    }
+    await wallet.connect();
+    if (wallet.isError) {
+      clearKeystoreSigner();
+      return wallet.message || "Could not connect the keystore wallet.";
+    }
+    return null;
+  }
+
+  async function handleFileChange(e) {
+    const file = e.target.files && e.target.files[0];
+    e.target.value = ""; // allow re-selecting the same file after an error
+    if (!file) return;
+    setUploadError(null);
+    try {
+      const text = await readFileAsText(file);
+      const json = JSON.parse(text);
+      const detected = detectKeystoreShape(json);
+      if (!detected) {
+        setUploadError("This does not look like an AssetMantle keystore file.");
+        return;
+      }
+      setFileText(text);
+      setFileJson(json);
+      setShape(detected);
+      setPassword("");
+      setPasswordError(null);
+      setStep("password");
+    } catch {
+      setUploadError(
+        "Could not read that file. Make sure it's a valid keystore .json export."
+      );
+    }
+  }
+
+  async function handlePasswordSubmit() {
+    if (busy || !password) return;
+    setBusy(true);
+    setPasswordError(null);
+    try {
+      if (shape === "legacy") {
+        const result = await decryptLegacyV1(fileJson, password);
+        if (result.error) {
+          setPasswordError(result.error);
+          return;
+        }
+        const { signer, address: addr } = await mnemonicToSigner(
+          result.mnemonic
+        );
+        const err = await connectKeystoreWallet(signer, addr);
+        if (err) {
+          setPasswordError(err);
+          return;
+        }
+        setLegacyMnemonic(result.mnemonic);
+        setUnlockSecret(password);
+        setAddress(addr);
+        setStep("legacyUpgrade");
+      } else {
+        let signer;
+        try {
+          signer = await importModern(fileText, password);
+        } catch {
+          setPasswordError("Incorrect password.");
+          return;
+        }
+        const [account] = await signer.getAccounts();
+        const err = await connectKeystoreWallet(signer, account.address);
+        if (err) {
+          setPasswordError(err);
+          return;
+        }
+        setUnlockSecret(password);
+        setAddress(account.address);
+        setStep("success");
+      }
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleUnlockWithPasskey() {
+    const saved = savedPasskey || loadPasskeyKeystore();
+    if (!saved || busy) return;
+    setBusy(true);
+    setMenuError(null);
+    try {
+      const prfSecretHex = await unlockPasskey({
+        credentialId: saved.credentialId,
+        prfSalt: saved.prfSalt,
+      });
+      const signer = await importModern(saved.modernBlob, prfSecretHex);
+      const [account] = await signer.getAccounts();
+      const err = await connectKeystoreWallet(signer, account.address);
+      if (err) {
+        setMenuError(err);
+        return;
+      }
+      setUnlockSecret(prfSecretHex);
+      setAddress(account.address);
+      setStep("success");
+    } catch (error) {
+      setMenuError(
+        error instanceof PrfUnsupportedError
+          ? "Passkey unlock isn't supported on this device/browser. Upload your keystore file and use your password instead."
+          : "Could not unlock with passkey. Try uploading your keystore file instead."
+      );
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleManualUpgradeDownload() {
+    try {
+      let blob = upgradeBlobRef.current;
+      if (!blob) {
+        blob = await exportModern(legacyMnemonic, unlockSecret);
+        upgradeBlobRef.current = blob;
+      }
+      downloadModernKeystore(blob, BACKUP_FILENAME);
+      setUpgradeError(null);
+    } catch {
+      setUpgradeError(
+        "Could not prepare the upgraded keystore file. Please try again."
+      );
+    }
+  }
+
+  async function handleDownloadKeystore() {
+    setActionError(null);
+    setActionMessage(null);
+    const { signer } = getKeystoreSigner();
+    if (!signer) {
+      setActionError("Keystore is locked. Reconnect and try again.");
+      return;
+    }
+    try {
+      const blob = await signer.serialize(unlockSecret);
+      downloadModernKeystore(blob, BACKUP_FILENAME);
+      setActionMessage("Keystore file downloaded.");
+    } catch {
+      setActionError("Could not prepare the keystore file for download.");
+    }
+  }
+
+  // TODO(manual-verify Task 6): this calls the real, already-unit-tested
+  // passkey.js/persist.js primitives end-to-end (enroll -> re-serialize ->
+  // persist) rather than a fake handler, but the interactive Touch-ID/PRF
+  // round trip itself can only be exercised in a real browser.
+  async function handleEnablePasskey() {
+    if (passkeyBusy) return;
+    const { signer } = getKeystoreSigner();
+    if (!signer) {
+      setActionError("Keystore is locked. Reconnect and try again.");
+      return;
+    }
+    setPasskeyBusy(true);
+    setActionError(null);
+    setActionMessage(null);
+    try {
+      // Force a backup download first: never let the account become
+      // solely reliant on this browser's localStorage + passkey.
+      const backupBlob = await signer.serialize(unlockSecret);
+      downloadModernKeystore(backupBlob, BACKUP_FILENAME);
+
+      const { credentialId, prfSalt, prfSecretHex } = await enrollPasskey({
+        rpId: window.location.hostname,
+        rpName: "AssetMantle Wallet",
+        userId: address,
+        userName: address,
+      });
+      const modernBlob = await signer.serialize(prfSecretHex);
+      savePasskeyKeystore({ credentialId, prfSalt, modernBlob });
+      setActionMessage(
+        "Passkey unlock enabled for this browser. A backup keystore file was downloaded too - keep it somewhere safe."
+      );
+    } catch (error) {
+      setActionError(
+        error instanceof PrfUnsupportedError
+          ? "This device/browser does not support passkey unlock (PRF). Use your password instead."
+          : "Could not enable passkey unlock."
+      );
+    } finally {
+      setPasskeyBusy(false);
+    }
+  }
+
+  const showBack = step === "menu" || step === "upload" || step === "password";
+  const title =
+    step === "upload"
+      ? "Upload Keystore File"
+      : step === "password"
+      ? "Enter Password"
+      : step === "legacyUpgrade"
+      ? "Upgrade Your Keystore"
+      : step === "success"
+      ? "Keystore Connected"
+      : "Connect with Keystore";
+
+  return (
+    <div className="bg-gray-800 p-4 rounded-4 w-100 my-auto">
+      <div className="d-flex align-items-center justify-content-between ">
+        <h1 className="body1 text-primary d-flex align-items-center gap-2">
+          {showBack && (
+            <button type="button" onClick={handleBack}>
+              <i className="bi bi-chevron-left" />
+            </button>
+          )}
+          {title}
+        </h1>
+        <button
+          type="button"
+          className="btn text-primary body1"
+          data-bs-dismiss="modal"
+          aria-label="Close"
+          onClick={onClose}
+        >
+          <span className="text-primary">
+            <i className="bi bi-x-lg" />
+          </span>
+        </button>
+      </div>
+
+      {step === "menu" && (
+        <div className="d-flex flex-column gap-3 mt-3">
+          <p className="text-white-200 caption my-1">
+            Import a keystore file to connect
+            {passkeyAvailable && savedPasskey
+              ? ", or unlock with the passkey you enabled in this browser."
+              : "."}
+          </p>
+          <button
+            type="button"
+            className="button-secondary py-2 px-4 rounded-2"
+            onClick={() => setStep("upload")}
+          >
+            Upload keystore file
+          </button>
+          {passkeyAvailable && savedPasskey && (
+            <button
+              type="button"
+              className="button-secondary py-2 px-4 rounded-2"
+              disabled={busy}
+              onClick={handleUnlockWithPasskey}
+            >
+              {busy ? "Unlocking..." : "Unlock with passkey"}
+            </button>
+          )}
+          {menuError && <p className="text-error caption">{menuError}</p>}
+        </div>
+      )}
+
+      {step === "upload" && (
+        <>
+          <p className="text-white-200 caption my-1 ps-2">
+            Upload the .json keystore file you exported from MantleWallet.
+          </p>
+          <div
+            className="d-flex align-items-center justify-content-center border-color-white rounded-0 position-relative mt-4"
+            style={{ border: "1px dashed" }}
+          >
+            <div className="d-flex flex-column text-primary p-3 text-center gap-3">
+              <span className="h4 text-primary mx-auto">
+                <i className="bi bi-upload" />
+              </span>
+              <p className="caption text-white">Drop file here</p>
+              <p className="caption text-white-200">or</p>
+              <div className="button-secondary py-2 px-5 d-flex align-items-center gap-2">
+                Browse <i className="bi bi-search" />
+              </div>
+            </div>
+            <input
+              type="file"
+              className="position-absolute top-0 bottom-0 start-0 end-0"
+              accept=".json"
+              style={{ opacity: "0" }}
+              onChange={handleFileChange}
+            />
+          </div>
+          {uploadError && (
+            <p className="text-error caption mt-2">{uploadError}</p>
+          )}
+        </>
+      )}
+
+      {step === "password" && (
+        <>
+          <p className="text-white-200 caption my-1">
+            Enter the password for this keystore file.
+          </p>
+          {shape === "legacy" && (
+            <p className="text-white-200 caption">
+              This is an older keystore file. After connecting, we&apos;ll
+              download an upgraded version - the old format embeds its own
+              decryption key and isn&apos;t safe to keep using.
+            </p>
+          )}
+          <input
+            type="password"
+            className="am-input w-100 my-3 py-2 px-3 rounded-1 bg-t border-color-white"
+            placeholder="******"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && handlePasswordSubmit()}
+          />
+          {passwordError && (
+            <p className="text-error caption">{passwordError}</p>
+          )}
+          <div className="d-flex align-items-center justify-content-end gap-3 flex-wrap mt-3">
+            <button
+              type="button"
+              className="button-primary caption py-2 px-5"
+              onClick={handlePasswordSubmit}
+              disabled={busy || !password}
+            >
+              {busy ? "Connecting..." : "Confirm"}
+            </button>
+          </div>
+        </>
+      )}
+
+      {step === "legacyUpgrade" && (
+        <div className="d-flex flex-column gap-3 mt-3">
+          <p className="d-flex align-items-start gap-1 text-error">
+            <span className="mt-1">
+              <i className="bi bi-exclamation-triangle" />
+            </span>
+            This old keystore file format is compromised by design - it carries
+            its own decryption key inside the file. An upgraded file has been
+            downloaded. Delete the old file and keep the new one instead.
+          </p>
+          {upgradeError && <p className="text-error caption">{upgradeError}</p>}
+          <button
+            type="button"
+            className="button-secondary py-2 px-4 rounded-2"
+            onClick={handleManualUpgradeDownload}
+          >
+            Download upgraded keystore file
+          </button>
+          <div className="d-flex w-100 mt-2">
+            <button
+              type="button"
+              className="am-link ms-auto px-3"
+              onClick={() => {
+                setLegacyMnemonic(null);
+                setStep("success");
+              }}
+            >
+              Continue
+            </button>
+          </div>
+        </div>
+      )}
+
+      {step === "success" && (
+        <div className="d-flex flex-column align-items-center justify-content-center text-center gap-3">
+          <span
+            className="text-success"
+            style={{ fontSize: "calc(10px + 10vmin)" }}
+          >
+            <i className="bi bi-check-circle" />
+          </span>
+          <h1 className="body2 text-primary">Keystore connected</h1>
+          <div className="nav-bg d-flex align-items-center justify-content-between flex-wrap w-100 p-3 rounded-2 caption">
+            <span className="text-gray">Address:</span>
+            {shortenAddress(address)}
+          </div>
+
+          <div className="d-flex flex-column w-100 gap-2 mt-2">
+            <button
+              type="button"
+              className="button-secondary py-2 px-4 rounded-2"
+              onClick={handleDownloadKeystore}
+            >
+              Download keystore
+            </button>
+            {passkeyAvailable && (
+              <button
+                type="button"
+                className="button-secondary py-2 px-4 rounded-2"
+                disabled={passkeyBusy}
+                onClick={handleEnablePasskey}
+              >
+                {passkeyBusy ? "Enabling..." : "Enable passkey unlock"}
+              </button>
+            )}
+            {actionError && <p className="text-error caption">{actionError}</p>}
+            {actionMessage && (
+              <p className="text-success caption">{actionMessage}</p>
+            )}
+          </div>
+
+          <div className="d-flex w-100 mt-2">
+            <button
+              type="button"
+              className="am-link ms-auto px-3"
+              data-bs-dismiss="modal"
+              onClick={onClose}
+            >
+              Done
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/views/Header.js
+++ b/views/Header.js
@@ -84,7 +84,12 @@ export default function Header({ setLeftCol }) {
     >
       <Link href="/">
         <a>
-          <Image src={NavBarData.logo} alt={NavBarData.title} priority={true} />
+          <Image
+            layout="fill"
+            src={NavBarData.logo}
+            alt={NavBarData.title}
+            priority={true}
+          />
         </a>
       </Link>
     </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,6 +10,17 @@
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.24"
 
+"@asamuzakjp/css-color@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@asamuzakjp/css-color/-/css-color-3.2.0.tgz#cc42f5b85c593f79f1fa4f25d2b9b321e61d1794"
+  integrity sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==
+  dependencies:
+    "@csstools/css-calc" "^2.1.3"
+    "@csstools/css-color-parser" "^3.0.9"
+    "@csstools/css-parser-algorithms" "^3.0.4"
+    "@csstools/css-tokenizer" "^3.0.3"
+    lru-cache "^10.4.3"
+
 "@babel/code-frame@^7.0.0":
   version "7.18.6"
   resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz"
@@ -17,7 +28,7 @@
   dependencies:
     "@babel/highlight" "^7.18.6"
 
-"@babel/code-frame@^7.18.6", "@babel/code-frame@^7.29.7":
+"@babel/code-frame@^7.18.6", "@babel/code-frame@^7.27.1", "@babel/code-frame@^7.29.7":
   version "7.29.7"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.29.7.tgz#f2fbbfea87c44a21590ec515b778b2c26d8866e7"
   integrity sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==
@@ -78,7 +89,7 @@
     json5 "^2.2.1"
     semver "^6.3.0"
 
-"@babel/core@^7.11.6", "@babel/core@^7.12.3":
+"@babel/core@^7.11.6", "@babel/core@^7.12.3", "@babel/core@^7.23.9", "@babel/core@^7.27.4":
   version "7.29.7"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.29.7.tgz#80c10b17248082968b57a857b91640971f2070f7"
   integrity sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==
@@ -117,7 +128,7 @@
     "@jridgewell/gen-mapping" "^0.3.2"
     jsesc "^2.5.1"
 
-"@babel/generator@^7.18.10", "@babel/generator@^7.19.3", "@babel/generator@^7.29.7":
+"@babel/generator@^7.18.10", "@babel/generator@^7.19.3", "@babel/generator@^7.27.5", "@babel/generator@^7.29.7":
   version "7.29.7"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.29.7.tgz#cca0b8827e6bcf3ba176788e7f3b180ad6db2fa3"
   integrity sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==
@@ -338,7 +349,7 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.18.11.tgz#68bb07ab3d380affa9a3f96728df07969645d2d9"
   integrity sha512-9JKn5vN+hDt0Hdqn1PiJ2guflwP+B6Ga8qbDuoF0PzzVhrzsKIJo8yGqVk6CmMHiMei9w1C1Bp9IMJSIK+HPIQ==
 
-"@babel/parser@^7.14.7", "@babel/parser@^7.18.10", "@babel/parser@^7.19.3", "@babel/parser@^7.29.7":
+"@babel/parser@^7.1.0", "@babel/parser@^7.14.7", "@babel/parser@^7.18.10", "@babel/parser@^7.19.3", "@babel/parser@^7.20.7", "@babel/parser@^7.23.9", "@babel/parser@^7.29.7":
   version "7.29.7"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.29.7.tgz#837b87387cbf5ec5530cb634b3c622f68edb9334"
   integrity sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==
@@ -516,6 +527,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
+"@babel/plugin-syntax-bigint@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz#4c9a6f669f5d0cdf1b90a1671e9a146be5300cea"
+  integrity sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.0"
+
 "@babel/plugin-syntax-class-properties@^7.12.13":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz#b5c987274c4a3a82b89714796931a6b53544ae10"
@@ -558,6 +576,20 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.29.7"
 
+"@babel/plugin-syntax-import-attributes@^7.24.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.29.7.tgz#6115264516e95ead0f35a41710906612e447f605"
+  integrity sha512-zGYcYfq/WmZ4V+kBIXQon9dSSc8ircGZqw9ZaNhhGj9nZkeBu1jHLBDQqYYi5WA9uawvA2sIMbry2nCFhf5Djg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+
+"@babel/plugin-syntax-import-meta@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz#ee601348c370fa334d2207be158777496521fd51"
+  integrity sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.10.4"
+
 "@babel/plugin-syntax-json-strings@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz#01ca21b668cd8218c9e640cb6dd88c5412b2c96a"
@@ -572,7 +604,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.18.6"
 
-"@babel/plugin-syntax-jsx@^7.29.7":
+"@babel/plugin-syntax-jsx@^7.27.1", "@babel/plugin-syntax-jsx@^7.29.7":
   version "7.29.7"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz#622c16f9ad63782fe6e83dadc7e40330744b7f1e"
   integrity sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==
@@ -635,7 +667,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
-"@babel/plugin-syntax-typescript@^7.29.7":
+"@babel/plugin-syntax-typescript@^7.27.1", "@babel/plugin-syntax-typescript@^7.29.7":
   version "7.29.7"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz#7c29388932313ed58413a0343048d75d92fb5b24"
   integrity sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==
@@ -1204,7 +1236,7 @@
     "@babel/helper-validator-identifier" "^7.19.1"
     to-fast-properties "^2.0.0"
 
-"@babel/types@^7.18.10", "@babel/types@^7.19.3", "@babel/types@^7.24.7", "@babel/types@^7.29.7", "@babel/types@^7.4.4":
+"@babel/types@^7.0.0", "@babel/types@^7.18.10", "@babel/types@^7.19.3", "@babel/types@^7.20.7", "@babel/types@^7.24.7", "@babel/types@^7.27.3", "@babel/types@^7.28.2", "@babel/types@^7.29.7", "@babel/types@^7.4.4":
   version "7.29.7"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.29.7.tgz#8005e31d82712ee7adaef6e23c63b71a62770a92"
   integrity sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==
@@ -1220,6 +1252,11 @@
     "@babel/helper-string-parser" "^7.19.4"
     "@babel/helper-validator-identifier" "^7.19.1"
     to-fast-properties "^2.0.0"
+
+"@bcoe/v8-coverage@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
+  integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
 "@chain-registry/cosmostation@1.8.0":
   version "1.8.0"
@@ -4086,10 +4123,60 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
+"@csstools/color-helpers@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@csstools/color-helpers/-/color-helpers-5.1.0.tgz#106c54c808cabfd1ab4c602d8505ee584c2996ef"
+  integrity sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==
+
+"@csstools/css-calc@^2.1.3", "@csstools/css-calc@^2.1.4":
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/@csstools/css-calc/-/css-calc-2.1.4.tgz#8473f63e2fcd6e459838dd412401d5948f224c65"
+  integrity sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==
+
+"@csstools/css-color-parser@^3.0.9":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz#4e386af3a99dd36c46fef013cfe4c1c341eed6f0"
+  integrity sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==
+  dependencies:
+    "@csstools/color-helpers" "^5.1.0"
+    "@csstools/css-calc" "^2.1.4"
+
+"@csstools/css-parser-algorithms@^3.0.4":
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz#5755370a9a29abaec5515b43c8b3f2cf9c2e3076"
+  integrity sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==
+
+"@csstools/css-tokenizer@^3.0.3":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz#333fedabc3fd1a8e5d0100013731cf19e6a8c5d3"
+  integrity sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==
+
 "@ctrl/tinycolor@^3.4.0":
   version "3.4.1"
   resolved "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.4.1.tgz"
   integrity sha512-ej5oVy6lykXsvieQtqZxCOaLT+xD4+QNarq78cIYISHmZXshCvROLudpQN3lfL8G0NL7plMSSK+zlyvCaIJ4Iw==
+
+"@emnapi/core@1.10.0":
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.10.0.tgz#380ccc8f2412ea22d1d972df7f8ee23a3b9c7467"
+  integrity sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==
+  dependencies:
+    "@emnapi/wasi-threads" "1.2.1"
+    tslib "^2.4.0"
+
+"@emnapi/runtime@1.10.0":
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-1.10.0.tgz#4b260c0d3534204e98c6110b8db1a987d26ec87c"
+  integrity sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==
+  dependencies:
+    tslib "^2.4.0"
+
+"@emnapi/wasi-threads@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz#28fed21a1ba1ce797c44a070abc94d42f3ae8548"
+  integrity sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==
+  dependencies:
+    tslib "^2.4.0"
 
 "@emotion/babel-plugin@^11.10.5":
   version "11.10.5"
@@ -4726,6 +4813,18 @@
   resolved "https://registry.yarnpkg.com/@iov/utils/-/utils-2.0.2.tgz#3527f376d26100e07ac823bf87bebd0f24680d1c"
   integrity sha512-4D8MEvTcFc/DVy5q25vHxRItmgJyeX85dixMH+MxdKr+yy71h3sYk+sVBEIn70uqGP7VqAJkGOPNFs08/XYELw==
 
+"@isaacs/cliui@^8.0.2":
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-8.0.2.tgz#b37667b7bc181c168782259bab42474fbf52b550"
+  integrity sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==
+  dependencies:
+    string-width "^5.1.2"
+    string-width-cjs "npm:string-width@^4.2.0"
+    strip-ansi "^7.0.1"
+    strip-ansi-cjs "npm:strip-ansi@^6.0.1"
+    wrap-ansi "^8.1.0"
+    wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"
@@ -4737,10 +4836,170 @@
     js-yaml "^3.13.1"
     resolve-from "^5.0.0"
 
-"@istanbuljs/schema@^0.1.2":
+"@istanbuljs/schema@^0.1.2", "@istanbuljs/schema@^0.1.3":
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.6.tgz#8dc9afa2ac1506cb1a58f89940f1c124446c8df3"
   integrity sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==
+
+"@jest/console@30.4.1":
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/@jest/console/-/console-30.4.1.tgz#e57725678c3fcc9f7e5597e691e454fee4ce0939"
+  integrity sha512-v3bhyxUh9Hgmo5p6hAOXe14/R3ZxZDOsvHleh4B07z3m/x4/ngPUXEm9XwK4sF4u+f+P2ORb0Ge+MgpaqRMVDA==
+  dependencies:
+    "@jest/types" "30.4.1"
+    "@types/node" "*"
+    chalk "^4.1.2"
+    jest-message-util "30.4.1"
+    jest-util "30.4.1"
+    slash "^3.0.0"
+
+"@jest/core@30.4.2":
+  version "30.4.2"
+  resolved "https://registry.yarnpkg.com/@jest/core/-/core-30.4.2.tgz#3d4081f894b7e2ff57d04a31842416bd07b76c32"
+  integrity sha512-TZJA6cPJUFxoWhxaLo8t0VX/MZX2wPWr0uIDvLSHIvN4gu9h02vSzqI2kBADG1ExqQlC+cY09xKMSreivvrChQ==
+  dependencies:
+    "@jest/console" "30.4.1"
+    "@jest/pattern" "30.4.0"
+    "@jest/reporters" "30.4.1"
+    "@jest/test-result" "30.4.1"
+    "@jest/transform" "30.4.1"
+    "@jest/types" "30.4.1"
+    "@types/node" "*"
+    ansi-escapes "^4.3.2"
+    chalk "^4.1.2"
+    ci-info "^4.2.0"
+    exit-x "^0.2.2"
+    fast-json-stable-stringify "^2.1.0"
+    graceful-fs "^4.2.11"
+    jest-changed-files "30.4.1"
+    jest-config "30.4.2"
+    jest-haste-map "30.4.1"
+    jest-message-util "30.4.1"
+    jest-regex-util "30.4.0"
+    jest-resolve "30.4.1"
+    jest-resolve-dependencies "30.4.2"
+    jest-runner "30.4.2"
+    jest-runtime "30.4.2"
+    jest-snapshot "30.4.1"
+    jest-util "30.4.1"
+    jest-validate "30.4.1"
+    jest-watcher "30.4.1"
+    pretty-format "30.4.1"
+    slash "^3.0.0"
+
+"@jest/diff-sequences@30.4.0":
+  version "30.4.0"
+  resolved "https://registry.yarnpkg.com/@jest/diff-sequences/-/diff-sequences-30.4.0.tgz#8be2d260e6241d6cddddd102c304fe13b4fc8e3e"
+  integrity sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==
+
+"@jest/environment-jsdom-abstract@30.4.1":
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/@jest/environment-jsdom-abstract/-/environment-jsdom-abstract-30.4.1.tgz#03cf1400aea958733f3a5d20cdc983ffcedfe2b1"
+  integrity sha512-dSlKrqug3siYNHVnjwIldShY12wAH3spwRltO/+8VOjg0X+xEq7vOs3DbBs4LRKsu7OH+NUb9kuZUNBF9Ho3TA==
+  dependencies:
+    "@jest/environment" "30.4.1"
+    "@jest/fake-timers" "30.4.1"
+    "@jest/types" "30.4.1"
+    "@types/jsdom" "^21.1.7"
+    "@types/node" "*"
+    jest-mock "30.4.1"
+    jest-util "30.4.1"
+
+"@jest/environment@30.4.1":
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-30.4.1.tgz#1ab5b736e3ce6336d59e00765fa24019649f1a30"
+  integrity sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w==
+  dependencies:
+    "@jest/fake-timers" "30.4.1"
+    "@jest/types" "30.4.1"
+    "@types/node" "*"
+    jest-mock "30.4.1"
+
+"@jest/expect-utils@30.4.1":
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/@jest/expect-utils/-/expect-utils-30.4.1.tgz#e0c7436d52b08610de9027841912dc3734ae80b2"
+  integrity sha512-ZBn5CglH8fBsQsvs4VWNzD4aWfUYks+IdOOQU3MEK71ol/BcVm+P+rtb1KpiFBpSWSCE27uOahyyf1vfqOVbcQ==
+  dependencies:
+    "@jest/get-type" "30.1.0"
+
+"@jest/expect@30.4.1":
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/@jest/expect/-/expect-30.4.1.tgz#7fefc67f86c2cb2af3c86d9d41fe4a1d74862b8c"
+  integrity sha512-ginrj6TMgh2GshLUGCjO94Ptx9HhdZA/I6A9iUfyeLKFtdAjnKzHDgzgP9HYQgbxM1lbXScQ2eUBz2lGeVDPWA==
+  dependencies:
+    expect "30.4.1"
+    jest-snapshot "30.4.1"
+
+"@jest/fake-timers@30.4.1":
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-30.4.1.tgz#ad2d3412d5d005a3e45740bd4c8ee1ccae2f89e1"
+  integrity sha512-iW5umdmfPeWzehrVhugFQZqCchSCud5S1l2YT0O9ZhjRR0ExclANDZkiSBwzqtnlOn0J1JXvO+HZ6rkuyOVOgQ==
+  dependencies:
+    "@jest/types" "30.4.1"
+    "@sinonjs/fake-timers" "^15.4.0"
+    "@types/node" "*"
+    jest-message-util "30.4.1"
+    jest-mock "30.4.1"
+    jest-util "30.4.1"
+
+"@jest/get-type@30.1.0":
+  version "30.1.0"
+  resolved "https://registry.yarnpkg.com/@jest/get-type/-/get-type-30.1.0.tgz#4fcb4dc2ebcf0811be1c04fd1cb79c2dba431cbc"
+  integrity sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==
+
+"@jest/globals@30.4.1":
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-30.4.1.tgz#6376975e137ef87926349b5e75ccf230f491e843"
+  integrity sha512-ZbuY4cmXC8DkxYjfvT2DbcHWL2T6vmsMhXCDcmTB2T0y0gaezBI77ufq5ZAIdcRkYZ7NEQEDg1xFeKbxUJ5v5Q==
+  dependencies:
+    "@jest/environment" "30.4.1"
+    "@jest/expect" "30.4.1"
+    "@jest/types" "30.4.1"
+    jest-mock "30.4.1"
+
+"@jest/pattern@30.4.0":
+  version "30.4.0"
+  resolved "https://registry.yarnpkg.com/@jest/pattern/-/pattern-30.4.0.tgz#fcb519eeacc25caa3768f787595a27afa15302ae"
+  integrity sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==
+  dependencies:
+    "@types/node" "*"
+    jest-regex-util "30.4.0"
+
+"@jest/reporters@30.4.1":
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/@jest/reporters/-/reporters-30.4.1.tgz#41d42533f199e737ae352a0a0b32ff300826efe2"
+  integrity sha512-/SnkPCzEQpUaBH81kjdEdDdo2WZl5hxw+BmLDGWjRkm8o7XlhjwsU36cqwe5PGBE5WYpBvDzRSdXx9rbGuJtNA==
+  dependencies:
+    "@bcoe/v8-coverage" "^0.2.3"
+    "@jest/console" "30.4.1"
+    "@jest/test-result" "30.4.1"
+    "@jest/transform" "30.4.1"
+    "@jest/types" "30.4.1"
+    "@jridgewell/trace-mapping" "^0.3.25"
+    "@types/node" "*"
+    chalk "^4.1.2"
+    collect-v8-coverage "^1.0.2"
+    exit-x "^0.2.2"
+    glob "^10.5.0"
+    graceful-fs "^4.2.11"
+    istanbul-lib-coverage "^3.0.0"
+    istanbul-lib-instrument "^6.0.0"
+    istanbul-lib-report "^3.0.0"
+    istanbul-lib-source-maps "^5.0.0"
+    istanbul-reports "^3.1.3"
+    jest-message-util "30.4.1"
+    jest-util "30.4.1"
+    jest-worker "30.4.1"
+    slash "^3.0.0"
+    string-length "^4.0.2"
+    v8-to-istanbul "^9.0.1"
+
+"@jest/schemas@30.4.1":
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/@jest/schemas/-/schemas-30.4.1.tgz#c3703fdd71357e2c83aa59bd38469e60a11529c6"
+  integrity sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==
+  dependencies:
+    "@sinclair/typebox" "^0.34.0"
 
 "@jest/schemas@^28.1.3":
   version "28.1.3"
@@ -4748,6 +5007,45 @@
   integrity sha512-/l/VWsdt/aBXgjshLWOFyFt3IVdYypu5y2Wn2rOO1un6nkqIn8SLXzgIMYXFyYsRWDyF5EthmKJMIdJvk08grg==
   dependencies:
     "@sinclair/typebox" "^0.24.1"
+
+"@jest/snapshot-utils@30.4.1":
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/@jest/snapshot-utils/-/snapshot-utils-30.4.1.tgz#0f829488b9d46b118854a16a56d509a3c6d9e064"
+  integrity sha512-ObY4ljvQ95mt6iwKtVLetR/4yXiAgl3H4nJxhztr0MTjrN97TwDYrnCp/kF60Ec9HdhkWTHSu+Hg05aXfngpOA==
+  dependencies:
+    "@jest/types" "30.4.1"
+    chalk "^4.1.2"
+    graceful-fs "^4.2.11"
+    natural-compare "^1.4.0"
+
+"@jest/source-map@30.0.1":
+  version "30.0.1"
+  resolved "https://registry.yarnpkg.com/@jest/source-map/-/source-map-30.0.1.tgz#305ebec50468f13e658b3d5c26f85107a5620aaa"
+  integrity sha512-MIRWMUUR3sdbP36oyNyhbThLHyJ2eEDClPCiHVbrYAe5g3CHRArIVpBw7cdSB5fr+ofSfIb2Tnsw8iEHL0PYQg==
+  dependencies:
+    "@jridgewell/trace-mapping" "^0.3.25"
+    callsites "^3.1.0"
+    graceful-fs "^4.2.11"
+
+"@jest/test-result@30.4.1":
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/@jest/test-result/-/test-result-30.4.1.tgz#e21146ebbb3e1f7f76c3c49805d9f39ae45f8de1"
+  integrity sha512-/ZG7pgEiOmmWkN9TplKbOu4id2N5lh7FHwRwlkgBVAzGdRH+OkkQ8wX/kIxg4zmd3ZQvAL1RwL2yWsvNYYECTw==
+  dependencies:
+    "@jest/console" "30.4.1"
+    "@jest/types" "30.4.1"
+    "@types/istanbul-lib-coverage" "^2.0.6"
+    collect-v8-coverage "^1.0.2"
+
+"@jest/test-sequencer@30.4.1":
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-30.4.1.tgz#caf9a5e0924ed3b04957441edf9e8cef6a804391"
+  integrity sha512-PeYE+4td5rKjoRPxztObrXU+H8hsjZfxKMXOcmrr34JerSyB/ROOxbbicz8B7A5j9R9VayDnVPvBmedqCsFCdw==
+  dependencies:
+    "@jest/test-result" "30.4.1"
+    graceful-fs "^4.2.11"
+    jest-haste-map "30.4.1"
+    slash "^3.0.0"
 
 "@jest/transform@28.1.3":
   version "28.1.3"
@@ -4769,6 +5067,39 @@
     pirates "^4.0.4"
     slash "^3.0.0"
     write-file-atomic "^4.0.1"
+
+"@jest/transform@30.4.1":
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-30.4.1.tgz#1646cddb800d38d9c4e30fecfd4a6eba0fa8acfa"
+  integrity sha512-Wz0LyktlTvRefoymh+n64hQ84KNXsRGcwdoZ8CSa0Ea+fgYcHZlnk+hDP7v2MS7il2bQ5uTEIxf4/NNfhMN4KQ==
+  dependencies:
+    "@babel/core" "^7.27.4"
+    "@jest/types" "30.4.1"
+    "@jridgewell/trace-mapping" "^0.3.25"
+    babel-plugin-istanbul "^7.0.1"
+    chalk "^4.1.2"
+    convert-source-map "^2.0.0"
+    fast-json-stable-stringify "^2.1.0"
+    graceful-fs "^4.2.11"
+    jest-haste-map "30.4.1"
+    jest-regex-util "30.4.0"
+    jest-util "30.4.1"
+    pirates "^4.0.7"
+    slash "^3.0.0"
+    write-file-atomic "^5.0.1"
+
+"@jest/types@30.4.1":
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-30.4.1.tgz#f79b647a85cb2ff4a90cc55984b31dae820db1f7"
+  integrity sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==
+  dependencies:
+    "@jest/pattern" "30.4.0"
+    "@jest/schemas" "30.4.1"
+    "@types/istanbul-lib-coverage" "^2.0.6"
+    "@types/istanbul-reports" "^3.0.4"
+    "@types/node" "*"
+    "@types/yargs" "^17.0.33"
+    chalk "^4.1.2"
 
 "@jest/types@^28.1.3":
   version "28.1.3"
@@ -4826,7 +5157,7 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@jridgewell/trace-mapping@^0.3.13", "@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.28":
+"@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.13", "@jridgewell/trace-mapping@^0.3.23", "@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25", "@jridgewell/trace-mapping@^0.3.28":
   version "0.3.31"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz#db15d6781c931f3a251a3dac39501c98a6082fd0"
   integrity sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==
@@ -5156,6 +5487,13 @@
     "@motionone/dom" "^10.15.5"
     tslib "^2.3.1"
 
+"@napi-rs/wasm-runtime@^1.1.4":
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz#ed33806d0f9be98dc76d0c3d4fd872fda701b5d5"
+  integrity sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==
+  dependencies:
+    "@tybys/wasm-util" "^0.10.3"
+
 "@next/env@12.3.7":
   version "12.3.7"
   resolved "https://registry.yarnpkg.com/@next/env/-/env-12.3.7.tgz#e706fbf66cdee012abe73aaa500d9df0b66a2db5"
@@ -5426,6 +5764,16 @@
   resolved "https://registry.yarnpkg.com/@pedrouid/environment/-/environment-1.0.1.tgz#858f0f8a057340e0b250398b75ead77d6f4342ec"
   integrity sha512-HaW78NszGzRZd9SeoI3JD11JqY+lubnaOx7Pewj5pfjqWXOEATpeKIFb9Z4t2WBUK2iryiXX3lzWwmYWgUL0Ug==
 
+"@pkgjs/parseargs@^0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
+  integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
+
+"@pkgr/core@^0.3.6":
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.3.6.tgz#3569708bd4be4d8870ba32bf1c456dac81600d97"
+  integrity sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==
+
 "@popperjs/core@^2.9.3":
   version "2.9.3"
   resolved "https://registry.npmjs.org/@popperjs/core/-/core-2.9.3.tgz"
@@ -5618,10 +5966,29 @@
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.24.51.tgz#645f33fe4e02defe26f2f5c0410e1c094eac7f5f"
   integrity sha512-1P1OROm/rdubP5aFDSZQILU0vrLCJ4fvHt6EoqHEM+2D/G5MK3bIaymUKLit8Js9gbns5UyJnkP/TZROLw4tUA==
 
+"@sinclair/typebox@^0.34.0":
+  version "0.34.49"
+  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.34.49.tgz#4f1369234f2ecf693866476c3b2e1b54d2a9d68e"
+  integrity sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==
+
 "@sindresorhus/is@^4.0.0", "@sindresorhus/is@^4.6.0":
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.6.0.tgz#3c7c9c46e678feefe7a2e5bb609d3dbd665ffb3f"
   integrity sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==
+
+"@sinonjs/commons@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-3.0.1.tgz#1029357e44ca901a615585f6d27738dbc89084cd"
+  integrity sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==
+  dependencies:
+    type-detect "4.0.8"
+
+"@sinonjs/fake-timers@^15.4.0":
+  version "15.4.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz#5d40c151a9e66075fe4520bec40bccfe54931962"
+  integrity sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==
+  dependencies:
+    "@sinonjs/commons" "^3.0.1"
 
 "@solana/buffer-layout@^4.0.0":
   version "4.0.1"
@@ -5871,10 +6238,50 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.3.tgz#472eaab5f15c1ffdd7f8628bd4c4f753995ec79e"
   integrity sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==
 
+"@tybys/wasm-util@^0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@tybys/wasm-util/-/wasm-util-0.10.3.tgz#015cba9e9dd47ce14d03d2a8c5d547bfb169665d"
+  integrity sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==
+  dependencies:
+    tslib "^2.4.0"
+
 "@types/abstract-leveldown@*":
   version "7.2.1"
   resolved "https://registry.yarnpkg.com/@types/abstract-leveldown/-/abstract-leveldown-7.2.1.tgz#bb16403c17754b0c4d5772d71d03b924a03d4c80"
   integrity sha512-YK8irIC+eMrrmtGx0H4ISn9GgzLd9dojZWJaMbjp1YHLl2VqqNFBNrL5Q3KjGf4VE3sf/4hmq6EhQZ7kZp1NoQ==
+
+"@types/babel__core@^7.20.5":
+  version "7.20.5"
+  resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.20.5.tgz#3df15f27ba85319caa07ba08d0721889bb39c017"
+  integrity sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==
+  dependencies:
+    "@babel/parser" "^7.20.7"
+    "@babel/types" "^7.20.7"
+    "@types/babel__generator" "*"
+    "@types/babel__template" "*"
+    "@types/babel__traverse" "*"
+
+"@types/babel__generator@*":
+  version "7.27.0"
+  resolved "https://registry.yarnpkg.com/@types/babel__generator/-/babel__generator-7.27.0.tgz#b5819294c51179957afaec341442f9341e4108a9"
+  integrity sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==
+  dependencies:
+    "@babel/types" "^7.0.0"
+
+"@types/babel__template@*":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@types/babel__template/-/babel__template-7.4.4.tgz#5672513701c1b2199bc6dad636a9d7491586766f"
+  integrity sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==
+  dependencies:
+    "@babel/parser" "^7.1.0"
+    "@babel/types" "^7.0.0"
+
+"@types/babel__traverse@*":
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/@types/babel__traverse/-/babel__traverse-7.28.0.tgz#07d713d6cce0d265c9849db0cbe62d3f61f36f74"
+  integrity sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==
+  dependencies:
+    "@babel/types" "^7.28.2"
 
 "@types/bn.js@^4.11.3":
   version "4.11.6"
@@ -5927,7 +6334,7 @@
   resolved "https://registry.yarnpkg.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz#0ea7b61496902b95890dc4c3a116b60cb8dae812"
   integrity sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ==
 
-"@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
+"@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1", "@types/istanbul-lib-coverage@^2.0.6":
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz#7739c232a1fee9b4d3ce8985f314c0c6d33549d7"
   integrity sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==
@@ -5939,12 +6346,21 @@
   dependencies:
     "@types/istanbul-lib-coverage" "*"
 
-"@types/istanbul-reports@^3.0.0":
+"@types/istanbul-reports@^3.0.0", "@types/istanbul-reports@^3.0.4":
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz#0f03e3d2f670fbdac586e34b433783070cc16f54"
   integrity sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==
   dependencies:
     "@types/istanbul-lib-report" "*"
+
+"@types/jsdom@^21.1.7":
+  version "21.1.7"
+  resolved "https://registry.yarnpkg.com/@types/jsdom/-/jsdom-21.1.7.tgz#9edcb09e0b07ce876e7833922d3274149c898cfa"
+  integrity sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==
+  dependencies:
+    "@types/node" "*"
+    "@types/tough-cookie" "*"
+    parse5 "^7.0.0"
 
 "@types/json-schema@^7.0.11":
   version "7.0.15"
@@ -6107,6 +6523,16 @@
   dependencies:
     "@types/node" "*"
 
+"@types/stack-utils@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.3.tgz#6209321eb2c1712a7e7466422b8cb1fc0d9dd5d8"
+  integrity sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==
+
+"@types/tough-cookie@*":
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.5.tgz#cb6e2a691b70cb177c6e3ae9c1d2e8b2ea8cd304"
+  integrity sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==
+
 "@types/trusted-types@^2.0.2":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.2.tgz#fc25ad9943bcac11cceb8168db4f275e0e72e756"
@@ -6124,7 +6550,7 @@
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.3.tgz#815e30b786d2e8f0dcd85fd5bcf5e1a04d008f15"
   integrity sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==
 
-"@types/yargs@^17.0.8":
+"@types/yargs@^17.0.33", "@types/yargs@^17.0.8":
   version "17.0.35"
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.35.tgz#07013e46aa4d7d7d50a49e15604c1c5340d4eb24"
   integrity sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==
@@ -6174,6 +6600,125 @@
   dependencies:
     "@typescript-eslint/types" "5.44.0"
     eslint-visitor-keys "^3.3.0"
+
+"@ungap/structured-clone@^1.3.0":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.3.2.tgz#a03ad82cd5676414d068ba86f880c5681194aadf"
+  integrity sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==
+
+"@unrs/resolver-binding-android-arm-eabi@1.12.2":
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.12.2.tgz#98a9fee62c01f209747a4ab5855f1ced38a6d03a"
+  integrity sha512-g5T90pqg1bo/7mytQx6F4iBNC0Wsh9cu+z9veDbFjc7HjpesJFWD7QMS0NGStXM075+7dJPPVvBbpZlnrdpi/w==
+
+"@unrs/resolver-binding-android-arm64@1.12.2":
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.12.2.tgz#46b7e8a1393f907462324f1576e8883529acf066"
+  integrity sha512-YGCRZv/9GLhwmz6mYDeTsm/92BAyR28l6c2ReweVW5pWgfsitWLY8upvfRlGdoyD8HjeTHSYJWyZGD4KJA/nFQ==
+
+"@unrs/resolver-binding-darwin-arm64@1.12.2":
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.12.2.tgz#0ea07b00e2583ab004b853d4c02ec5f0745d490c"
+  integrity sha512-u9DiNT1auQMO20A9SyTuG3wUgQWB9Z7KjAg0uFuCDR1FsAY8A0CG2S6JpHS1xwm/w1G08bjXZDcyOCjv1WAm2w==
+
+"@unrs/resolver-binding-darwin-x64@1.12.2":
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.12.2.tgz#a2a6901ed58449b91b4438e582f6890cba956049"
+  integrity sha512-f7rPLi/T1HVKZu/u6t87lroib16n8vrSzcyxI7lg4BGO9UF26KhQL44sd9eOUgrTYhvRXtWOIZT5PejdPyJfUA==
+
+"@unrs/resolver-binding-freebsd-x64@1.12.2":
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.12.2.tgz#ebe6fe7f6706b7378ea4a48a024602e9c2f48f89"
+  integrity sha512-BpcOjWCJub6nRZUS2zA20pmLvjtqAtGejETaIyRLiZiQf++cbrjltLA5NN/xaXfqeOBOSlMFbemIl5/S5tljmg==
+
+"@unrs/resolver-binding-linux-arm-gnueabihf@1.12.2":
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.12.2.tgz#e6040fedaa240124419d35b25b69c5fa15ddb499"
+  integrity sha512-vZTDvdSISZjJx66OzJqtsOhzifbqRjbmI1Mnu49fQDwog5GtDI4QidRiEAYbZCRj9C8YZEW+3ZjqsyS9GR4k2A==
+
+"@unrs/resolver-binding-linux-arm-musleabihf@1.12.2":
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.12.2.tgz#d217a8fb59f659c131539326c140e7b62e3e3c6a"
+  integrity sha512-BiPI+IrIlwcW4nLLMM21+B1dFPzd55yAVgVGrdgDjNef+ch03GdxrcyaIz8X9SsQirh/kCQ7mviyWlMxdh2D7g==
+
+"@unrs/resolver-binding-linux-arm64-gnu@1.12.2":
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.12.2.tgz#edab13c46a45783a7e01351e113825c04f352e24"
+  integrity sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==
+
+"@unrs/resolver-binding-linux-arm64-musl@1.12.2":
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.12.2.tgz#e5e195db1130f7d3b6aa2fd67b3c9fe1ea4859a0"
+  integrity sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==
+
+"@unrs/resolver-binding-linux-loong64-gnu@1.12.2":
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-loong64-gnu/-/resolver-binding-linux-loong64-gnu-1.12.2.tgz#f01d22e091bae13016f4636698d9dcbbda775c3e"
+  integrity sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==
+
+"@unrs/resolver-binding-linux-loong64-musl@1.12.2":
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-loong64-musl/-/resolver-binding-linux-loong64-musl-1.12.2.tgz#7d23efcb98adf076bfbcecc27b4212c36aa6697d"
+  integrity sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==
+
+"@unrs/resolver-binding-linux-ppc64-gnu@1.12.2":
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.12.2.tgz#1f35f1eaa322f33cf2d96dac27f0626a93ffe2f6"
+  integrity sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==
+
+"@unrs/resolver-binding-linux-riscv64-gnu@1.12.2":
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.12.2.tgz#674faa696f5ce96f214873946a1e2d6ca96723dd"
+  integrity sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==
+
+"@unrs/resolver-binding-linux-riscv64-musl@1.12.2":
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.12.2.tgz#37835fdd0b472ecdcffccd4288f19018454b138c"
+  integrity sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==
+
+"@unrs/resolver-binding-linux-s390x-gnu@1.12.2":
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.12.2.tgz#b6edf13db4bb0accdcd1ad482a4eea0301de9224"
+  integrity sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==
+
+"@unrs/resolver-binding-linux-x64-gnu@1.12.2":
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.12.2.tgz#daddad00bf65a405202284da1eb1db8eb83b218f"
+  integrity sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==
+
+"@unrs/resolver-binding-linux-x64-musl@1.12.2":
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.12.2.tgz#dfdff1e0c2bad25420b41c76a746011c3983b9bb"
+  integrity sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==
+
+"@unrs/resolver-binding-openharmony-arm64@1.12.2":
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-openharmony-arm64/-/resolver-binding-openharmony-arm64-1.12.2.tgz#ce07c4f5e7b42f7bfce45e7629b8659063aefefe"
+  integrity sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==
+
+"@unrs/resolver-binding-wasm32-wasi@1.12.2":
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.12.2.tgz#82514f0506cfaf65f17fe16095f92d450e487183"
+  integrity sha512-tYFDIkMxSflfEc/h92ZWNsZlHSwgimbNHSO3PL2JWQHfCuC2q316jMyYU9TIWZsFK2bQwyK5VAdYgn8ygPj69A==
+  dependencies:
+    "@emnapi/core" "1.10.0"
+    "@emnapi/runtime" "1.10.0"
+    "@napi-rs/wasm-runtime" "^1.1.4"
+
+"@unrs/resolver-binding-win32-arm64-msvc@1.12.2":
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.12.2.tgz#521427dd59a8f4740ddd1dc7c3bc6af1aa1d260d"
+  integrity sha512-qzNyg3xL0VPQmCaUh+N5jSitce6k+uCBfMDesWRnlULOZaqUkaJ0ybdT+UqlAWJoQjuqfIU/0Ptx9bteN4D82g==
+
+"@unrs/resolver-binding-win32-ia32-msvc@1.12.2":
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.12.2.tgz#05b63286ff2da37e0ce3083b8390884385efff62"
+  integrity sha512-WD9sY00OfpHVGfsnHZoA8jVT+esS/Bg8z8jzxp5BnDCjjwsuKsPQrzswwpFy4J1AUJbXPRfkpcX0mXrzeXW79g==
+
+"@unrs/resolver-binding-win32-x64-msvc@1.12.2":
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.12.2.tgz#72da0da48d72b1e87831b9c0308931d3f4669027"
+  integrity sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==
 
 "@vectis/extension-client@0.6.0":
   version "0.6.0"
@@ -6853,6 +7398,11 @@ agent-base@6:
   dependencies:
     debug "4"
 
+agent-base@^7.1.0, agent-base@^7.1.2:
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-7.1.4.tgz#e3cd76d4c548ee895d3c3fd8dc1f6c5b9032e7a8"
+  integrity sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==
+
 agentkeepalive@^4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/agentkeepalive/-/agentkeepalive-4.2.1.tgz#a7975cbb9f83b367f06c90cc51ff28fe7d499717"
@@ -6886,6 +7436,13 @@ ansi-escapes@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
   integrity sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==
+
+ansi-escapes@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.2.tgz#6b2291d1db7d98b6521d5f1efa42d0f3a9feb65e"
+  integrity sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==
+  dependencies:
+    type-fest "^0.21.3"
 
 ansi-escapes@^7.0.0:
   version "7.3.0"
@@ -6938,7 +7495,12 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   dependencies:
     color-convert "^2.0.1"
 
-ansi-styles@^6.2.1, ansi-styles@^6.2.3:
+ansi-styles@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
+  integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
+
+ansi-styles@^6.1.0, ansi-styles@^6.2.1, ansi-styles@^6.2.3:
   version "6.2.3"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.3.tgz#c044d5dcc521a076413472597a1acb1f103c4041"
   integrity sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==
@@ -6948,7 +7510,7 @@ any-promise@^1.0.0:
   resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
   integrity sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==
 
-anymatch@^3.0.3:
+anymatch@^3.0.3, anymatch@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.3.tgz#790c58b19ba1720a84205b57c618d5ad8524973e"
   integrity sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==
@@ -7136,6 +7698,19 @@ axobject-query@^2.2.0:
   resolved "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz"
   integrity sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==
 
+babel-jest@30.4.1:
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-30.4.1.tgz#63cba904438bbe64c4cf0acdea87b0a45cb809fc"
+  integrity sha512-fATAbM8piYxkiXQp3RBXmZHxZVNJZAVXXfyeyCN2Tida3+qJ8ea9UxhiJ2y4fLO90ZImKt6k9FlcH2+rLkJGhw==
+  dependencies:
+    "@jest/transform" "30.4.1"
+    "@types/babel__core" "^7.20.5"
+    babel-plugin-istanbul "^7.0.1"
+    babel-preset-jest "30.4.0"
+    chalk "^4.1.2"
+    graceful-fs "^4.2.11"
+    slash "^3.0.0"
+
 babel-plugin-istanbul@^6.1.1:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz#fa88ec59232fd9b4e36dbbc540a8ec9a9b47da73"
@@ -7146,6 +7721,24 @@ babel-plugin-istanbul@^6.1.1:
     "@istanbuljs/schema" "^0.1.2"
     istanbul-lib-instrument "^5.0.4"
     test-exclude "^6.0.0"
+
+babel-plugin-istanbul@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.1.tgz#d8b518c8ea199364cf84ccc82de89740236daf92"
+  integrity sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@istanbuljs/load-nyc-config" "^1.0.0"
+    "@istanbuljs/schema" "^0.1.3"
+    istanbul-lib-instrument "^6.0.2"
+    test-exclude "^6.0.0"
+
+babel-plugin-jest-hoist@30.4.0:
+  version "30.4.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.4.0.tgz#f7d6a6d8f435808b56b45a81dc4b61a39e36794a"
+  integrity sha512-9EdtWM/sSfXLOGLwSn+GS6pIXyBnL07/8gyJlwFXjWy4DxMOyItqyUT29d4lQiS380EZwYlX7/At4PgBS+m2aA==
+  dependencies:
+    "@types/babel__core" "^7.20.5"
 
 babel-plugin-macros@^3.1.0:
   version "3.1.0"
@@ -7187,6 +7780,35 @@ babel-plugin-polyfill-regenerator@^0.4.0, babel-plugin-polyfill-regenerator@^0.4
   integrity sha512-NtQGmyQDXjQqQ+IzRkBVwEOz9lQ4zxAQZgoAYEtU9dJjnl1Oc98qnN7jcp+bE7O7aYzVpavXE3/VKXNzUbh7aw==
   dependencies:
     "@babel/helper-define-polyfill-provider" "^0.3.3"
+
+babel-preset-current-node-syntax@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz#20730d6cdc7dda5d89401cab10ac6a32067acde6"
+  integrity sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==
+  dependencies:
+    "@babel/plugin-syntax-async-generators" "^7.8.4"
+    "@babel/plugin-syntax-bigint" "^7.8.3"
+    "@babel/plugin-syntax-class-properties" "^7.12.13"
+    "@babel/plugin-syntax-class-static-block" "^7.14.5"
+    "@babel/plugin-syntax-import-attributes" "^7.24.7"
+    "@babel/plugin-syntax-import-meta" "^7.10.4"
+    "@babel/plugin-syntax-json-strings" "^7.8.3"
+    "@babel/plugin-syntax-logical-assignment-operators" "^7.10.4"
+    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.3"
+    "@babel/plugin-syntax-numeric-separator" "^7.10.4"
+    "@babel/plugin-syntax-object-rest-spread" "^7.8.3"
+    "@babel/plugin-syntax-optional-catch-binding" "^7.8.3"
+    "@babel/plugin-syntax-optional-chaining" "^7.8.3"
+    "@babel/plugin-syntax-private-property-in-object" "^7.14.5"
+    "@babel/plugin-syntax-top-level-await" "^7.14.5"
+
+babel-preset-jest@30.4.0:
+  version "30.4.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-30.4.0.tgz#295486c2ec1127b3dc7d0d2adaa72a1dcaaafccd"
+  integrity sha512-lBY4jxsNmCnSiu7kquw8ZC9F4+XLMOKypT3RnNHPvU2Kpd4W0xaPuLr5ZkRyOsvLYAY4yaW1ZwTW4xB7NIiZzg==
+  dependencies:
+    babel-plugin-jest-hoist "30.4.0"
+    babel-preset-current-node-syntax "^1.2.0"
 
 balanced-match@^1.0.0:
   version "1.0.2"
@@ -7449,7 +8071,7 @@ buffer-fill@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-fill/-/buffer-fill-1.0.0.tgz#f8f78b76789888ef39f205cd637f68e702122b2c"
   integrity sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==
 
-buffer-from@^1.1.1:
+buffer-from@^1.0.0, buffer-from@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
@@ -7570,7 +8192,7 @@ call-me-maybe@^1.0.1:
   resolved "https://registry.yarnpkg.com/call-me-maybe/-/call-me-maybe-1.0.2.tgz#03f964f19522ba643b1b0693acb9152fe2074baa"
   integrity sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==
 
-callsites@^3.0.0:
+callsites@^3.0.0, callsites@^3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
@@ -7580,7 +8202,7 @@ camelcase@^5.0.0, camelcase@^5.3.1:
   resolved "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
-camelcase@^6.0.0:
+camelcase@^6.0.0, camelcase@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
@@ -7653,13 +8275,18 @@ chalk@^2.0.0, chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^4.0.0, chalk@^4.1.0:
+chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
+
+char-regex@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
+  integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
 
 chardet@^0.4.0:
   version "0.4.2"
@@ -7721,6 +8348,11 @@ ci-info@^3.2.0:
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.9.0.tgz#4279a62028a7b1f262f3473fc9605f5e218c59b4"
   integrity sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==
 
+ci-info@^4.2.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-4.4.0.tgz#7d54eff9f54b45b62401c26032696eb59c8bd18c"
+  integrity sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==
+
 cids@^0.7.1:
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/cids/-/cids-0.7.5.tgz#60a08138a99bfb69b6be4ceb63bfef7a396b28b2"
@@ -7740,6 +8372,11 @@ cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3, cipher-base@^1.0.5:
     inherits "^2.0.4"
     safe-buffer "^5.2.1"
     to-buffer "^1.2.2"
+
+cjs-module-lexer@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz#b3ca5101843389259ade7d88c77bd06ce55849ca"
+  integrity sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==
 
 class-is@^1.1.0:
   version "1.1.0"
@@ -7816,6 +8453,15 @@ cliui@^7.0.2:
     strip-ansi "^6.0.0"
     wrap-ansi "^7.0.0"
 
+cliui@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-8.0.1.tgz#0c04b075db02cbfe60dc8e6cf2f5486b1a3608aa"
+  integrity sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.1"
+    wrap-ansi "^7.0.0"
+
 clone-response@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/clone-response/-/clone-response-1.0.3.tgz#af2032aa47816399cf5f0a1d0db902f517abb8c3"
@@ -7832,6 +8478,16 @@ clsx@^1.1.0, clsx@^1.1.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.2.1.tgz#0ddc4a20a549b59c93a4116bb26f5294ca17dc12"
   integrity sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==
+
+co@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
+  integrity sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==
+
+collect-v8-coverage@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz#cc1f01eb8d02298cbc9a437c74c70ab4e5210b80"
+  integrity sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==
 
 color-convert@^1.9.0:
   version "1.9.3"
@@ -8071,6 +8727,15 @@ cross-spawn@^7.0.2:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+cross-spawn@^7.0.3, cross-spawn@^7.0.6:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
+  integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
+
 crypt@~0.0.1:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
@@ -8087,6 +8752,14 @@ css-box-model@1.2.1:
   integrity sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==
   dependencies:
     tiny-invariant "^1.0.6"
+
+cssstyle@^4.2.1:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-4.6.0.tgz#ea18007024e3167f4f105315f3ec2d982bf48ed9"
+  integrity sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==
+  dependencies:
+    "@asamuzakjp/css-color" "^3.2.0"
+    rrweb-cssom "^0.8.0"
 
 csstype@^3.0.11, csstype@^3.0.2:
   version "3.1.1"
@@ -8210,6 +8883,14 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+data-urls@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-5.0.0.tgz#2f76906bce1824429ffecb6920f45a0b30f00dde"
+  integrity sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==
+  dependencies:
+    whatwg-mimetype "^4.0.0"
+    whatwg-url "^14.0.0"
+
 debug@2.6.9, debug@^2.2.0, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
@@ -8255,6 +8936,11 @@ decamelize@^4.0.0:
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-4.0.0.tgz#aa472d7bf660eb15f3494efd531cab7f2a709837"
   integrity sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==
 
+decimal.js@^10.5.0:
+  version "10.6.0"
+  resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.6.0.tgz#e649a43e3ab953a72192ff5983865e509f37ed9a"
+  integrity sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==
+
 decode-uri-component@^0.2.0:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.2.tgz#e69dbe25d37941171dd540e024c444cd5188e1e9"
@@ -8274,6 +8960,11 @@ decompress-response@^6.0.0:
   dependencies:
     mimic-response "^3.1.0"
 
+dedent@^1.6.0:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/dedent/-/dedent-1.7.2.tgz#34e2264ab538301e27cf7b07bf2369c19baa8dd9"
+  integrity sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==
+
 deep-eql@^4.1.2:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-4.1.3.tgz#7c7775513092f7df98d8df9996dd085eb668cc6d"
@@ -8290,6 +8981,11 @@ deepmerge@4.2.2:
   version "4.2.2"
   resolved "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz"
   integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
+
+deepmerge@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.3.1.tgz#44b5f2147cd3b00d4b56137685966f26fd25dd4a"
+  integrity sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==
 
 defer-to-connect@^2.0.0, defer-to-connect@^2.0.1:
   version "2.0.1"
@@ -8360,6 +9056,11 @@ detect-browser@5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/detect-browser/-/detect-browser-5.3.0.tgz#9705ef2bddf46072d0f7265a1fe300e36fe7ceca"
   integrity sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w==
+
+detect-newline@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
+  integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
 detect-node-es@^1.1.0:
   version "1.1.0"
@@ -8439,6 +9140,11 @@ duplexify@^4.1.2:
     readable-stream "^3.1.1"
     stream-shift "^1.0.0"
 
+eastasianwidth@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
+  integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
+
 ecc-jsbn@~0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
@@ -8481,6 +9187,11 @@ elliptic@6.5.4, elliptic@^6.4.0, elliptic@^6.5.2, elliptic@^6.5.3, elliptic@^6.5
     inherits "^2.0.4"
     minimalistic-assert "^1.0.1"
     minimalistic-crypto-utils "^1.0.1"
+
+emittery@^0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/emittery/-/emittery-0.13.1.tgz#c04b8c3457490e0847ae51fced3af52d338e3dad"
+  integrity sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==
 
 emoji-regex@^10.3.0:
   version "10.6.0"
@@ -8533,6 +9244,11 @@ enquire.js@^2.1.6:
   version "2.1.6"
   resolved "https://registry.yarnpkg.com/enquire.js/-/enquire.js-2.1.6.tgz#3e8780c9b8b835084c3f60e166dbc3c2a3c89814"
   integrity sha512-/KujNpO+PT63F7Hlpu4h3pE3TokKRHN26JYmQpPyjkRD/N57R7bPDNojMXdi7uveAKjYB7yQnartCxZnFWr0Xw==
+
+entities@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-6.0.1.tgz#c28c34a43379ca7f61d074130b2f5f7020a30694"
+  integrity sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==
 
 environment@^1.0.0:
   version "1.1.0"
@@ -8708,6 +9424,11 @@ escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
+
+escape-string-regexp@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
+  integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
 
 eslint-config-next@12.2.5:
   version "12.2.5"
@@ -9233,6 +9954,38 @@ evp_bytestokey@^1.0.3:
     md5.js "^1.3.4"
     safe-buffer "^5.1.1"
 
+execa@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-5.1.1.tgz#f80ad9cbf4298f7bd1d4c9555c21e93741c411dd"
+  integrity sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==
+  dependencies:
+    cross-spawn "^7.0.3"
+    get-stream "^6.0.0"
+    human-signals "^2.1.0"
+    is-stream "^2.0.0"
+    merge-stream "^2.0.0"
+    npm-run-path "^4.0.1"
+    onetime "^5.1.2"
+    signal-exit "^3.0.3"
+    strip-final-newline "^2.0.0"
+
+exit-x@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/exit-x/-/exit-x-0.2.2.tgz#1f9052de3b8d99a696b10dad5bced9bdd5c3aa64"
+  integrity sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==
+
+expect@30.4.1:
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-30.4.1.tgz#897e0390a0b6c333dbcf3a24dee3ad49553577e0"
+  integrity sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==
+  dependencies:
+    "@jest/expect-utils" "30.4.1"
+    "@jest/get-type" "30.1.0"
+    jest-matcher-utils "30.4.1"
+    jest-message-util "30.4.1"
+    jest-mock "30.4.1"
+    jest-util "30.4.1"
+
 express@^4.14.0:
   version "4.18.2"
   resolved "https://registry.yarnpkg.com/express/-/express-4.18.2.tgz#3fabe08296e930c796c19e3c516979386ba9fd59"
@@ -9348,7 +10101,7 @@ fast-glob@^3.2.9:
     merge2 "^1.3.0"
     micromatch "^4.0.4"
 
-fast-json-stable-stringify@^2.0.0:
+fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
@@ -9380,7 +10133,7 @@ fastq@^1.6.0:
   dependencies:
     reusify "^1.0.4"
 
-fb-watchman@^2.0.0:
+fb-watchman@^2.0.0, fb-watchman@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/fb-watchman/-/fb-watchman-2.0.2.tgz#e9524ee6b5c77e9e5001af0f85f3adbb8623255c"
   integrity sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==
@@ -9451,7 +10204,7 @@ find-up@^3.0.0:
   dependencies:
     locate-path "^3.0.0"
 
-find-up@^4.1.0:
+find-up@^4.0.0, find-up@^4.1.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz"
   integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
@@ -9509,6 +10262,14 @@ for-each@^0.3.5:
   integrity sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==
   dependencies:
     is-callable "^1.2.7"
+
+foreground-child@^3.1.0:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-3.3.1.tgz#32e8e9ed1b68a3497befb9ac2b6adf92a638576f"
+  integrity sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==
+  dependencies:
+    cross-spawn "^7.0.6"
+    signal-exit "^4.0.1"
 
 forever-agent@~0.6.1:
   version "0.6.1"
@@ -9614,7 +10375,7 @@ fs.realpath@^1.0.0:
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
-fsevents@^2.3.2:
+fsevents@^2.3.2, fsevents@^2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
@@ -9734,7 +10495,7 @@ get-stream@^5.1.0:
   dependencies:
     pump "^3.0.0"
 
-get-stream@^6.0.1:
+get-stream@^6.0.0, get-stream@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
   integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
@@ -9809,6 +10570,18 @@ glob@8.0.3:
     inherits "2"
     minimatch "^5.0.1"
     once "^1.3.0"
+
+glob@^10.5.0:
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-10.5.0.tgz#8ec0355919cd3338c28428a23d4f24ecc5fe738c"
+  integrity sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==
+  dependencies:
+    foreground-child "^3.1.0"
+    jackspeak "^3.1.2"
+    minimatch "^9.0.4"
+    minipass "^7.1.2"
+    package-json-from-dist "^1.0.0"
+    path-scurry "^1.11.1"
 
 glob@^7.0.0, glob@^7.1.4, glob@^7.1.6, glob@^7.2.0:
   version "7.2.3"
@@ -9909,7 +10682,7 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
 
-graceful-fs@^4.2.9:
+graceful-fs@^4.2.11, graceful-fs@^4.2.9:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
@@ -10067,6 +10840,18 @@ hoist-non-react-statics@^3.3.1:
   dependencies:
     react-is "^16.7.0"
 
+html-encoding-sniffer@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz#696df529a7cfd82446369dc5193e590a3735b448"
+  integrity sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==
+  dependencies:
+    whatwg-encoding "^3.1.1"
+
+html-escaper@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
+  integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
+
 http-cache-semantics@^4.0.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz#abe02fcb2985460bf0323be664436ec3476a6d5a"
@@ -10087,6 +10872,14 @@ http-https@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/http-https/-/http-https-1.0.0.tgz#2f908dd5f1db4068c058cd6e6d4ce392c913389b"
   integrity sha512-o0PWwVCSp3O0wS6FvNr6xfBCHgt0m1tvPLFOCc2iFDKTRAXhB7m8klDf7ErowFH8POa6dVdGatKU5I1YYwzUyg==
+
+http-proxy-agent@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz#9a8b1f246866c028509486585f62b8f2c18c270e"
+  integrity sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==
+  dependencies:
+    agent-base "^7.1.0"
+    debug "^4.3.4"
 
 http-signature@~1.2.0:
   version "1.2.0"
@@ -10121,6 +10914,19 @@ https-proxy-agent@^5.0.1:
     agent-base "6"
     debug "4"
 
+https-proxy-agent@^7.0.6:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz#da8dfeac7da130b05c2ba4b59c9b6cd66611a6b9"
+  integrity sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==
+  dependencies:
+    agent-base "^7.1.2"
+    debug "4"
+
+human-signals@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
+  integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
+
 humanize-ms@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/humanize-ms/-/humanize-ms-1.2.1.tgz#c46e3159a293f6b896da29316d8b6fe8bb79bbed"
@@ -10139,6 +10945,13 @@ iconv-lite@0.4.24, iconv-lite@^0.4.17, iconv-lite@^0.4.24:
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
+
+iconv-lite@0.6.3:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
+  integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
 
 idna-uts46-hx@^2.3.1:
   version "2.3.1"
@@ -10179,6 +10992,14 @@ import-fresh@^3.0.0, import-fresh@^3.2.1:
   dependencies:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
+
+import-local@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/import-local/-/import-local-3.2.0.tgz#c3d5c745798c02a6f8b897726aba5100186ee260"
+  integrity sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==
+  dependencies:
+    pkg-dir "^4.2.0"
+    resolve-cwd "^3.0.0"
 
 imurmurhash@^0.1.4:
   version "0.1.4"
@@ -10388,6 +11209,11 @@ is-function@^1.0.1:
   resolved "https://registry.yarnpkg.com/is-function/-/is-function-1.0.2.tgz#4f097f30abf6efadac9833b17ca5dc03f8144e08"
   integrity sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ==
 
+is-generator-fn@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.1.0.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
+  integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
+
 is-generator-function@^1.0.7:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/is-generator-function/-/is-generator-function-1.0.10.tgz#f1558baf1ac17e0deea7c0415c438351ff2b3c72"
@@ -10434,6 +11260,11 @@ is-plain-obj@^2.1.0:
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.1.0.tgz#45e42e37fccf1f40da8e5f76ee21515840c09287"
   integrity sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==
 
+is-potential-custom-element-name@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz#171ed6f19e3ac554394edf78caa05784a45bebb5"
+  integrity sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==
+
 is-promise@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.2.2.tgz#39ab959ccbf9a774cf079f7b40c7a26f763135f1"
@@ -10453,6 +11284,11 @@ is-shared-array-buffer@^1.0.2:
   integrity sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==
   dependencies:
     call-bind "^1.0.2"
+
+is-stream@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.1.tgz#fac1e3d53b97ad5a9d0ae9cef2389f5810a5c077"
+  integrity sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==
 
 is-string@^1.0.5, is-string@^1.0.7:
   version "1.0.7"
@@ -10528,7 +11364,7 @@ isstream@~0.1.2:
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
   integrity sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==
 
-istanbul-lib-coverage@^3.2.0:
+istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz#2d166c4b0644d43a39f04bf6c2edd1e585f31756"
   integrity sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==
@@ -10543,6 +11379,52 @@ istanbul-lib-instrument@^5.0.4:
     "@istanbuljs/schema" "^0.1.2"
     istanbul-lib-coverage "^3.2.0"
     semver "^6.3.0"
+
+istanbul-lib-instrument@^6.0.0, istanbul-lib-instrument@^6.0.2:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz#fa15401df6c15874bcb2105f773325d78c666765"
+  integrity sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==
+  dependencies:
+    "@babel/core" "^7.23.9"
+    "@babel/parser" "^7.23.9"
+    "@istanbuljs/schema" "^0.1.3"
+    istanbul-lib-coverage "^3.2.0"
+    semver "^7.5.4"
+
+istanbul-lib-report@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz#908305bac9a5bd175ac6a74489eafd0fc2445a7d"
+  integrity sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==
+  dependencies:
+    istanbul-lib-coverage "^3.0.0"
+    make-dir "^4.0.0"
+    supports-color "^7.1.0"
+
+istanbul-lib-source-maps@^5.0.0:
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz#acaef948df7747c8eb5fbf1265cb980f6353a441"
+  integrity sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==
+  dependencies:
+    "@jridgewell/trace-mapping" "^0.3.23"
+    debug "^4.1.1"
+    istanbul-lib-coverage "^3.0.0"
+
+istanbul-reports@^3.1.3:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-3.2.0.tgz#cb4535162b5784aa623cee21a7252cf2c807ac93"
+  integrity sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==
+  dependencies:
+    html-escaper "^2.0.0"
+    istanbul-lib-report "^3.0.0"
+
+jackspeak@^3.1.2:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/jackspeak/-/jackspeak-3.4.3.tgz#8833a9d89ab4acde6188942bd1c53b6390ed5a8a"
+  integrity sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==
+  dependencies:
+    "@isaacs/cliui" "^8.0.2"
+  optionalDependencies:
+    "@pkgjs/parseargs" "^0.11.0"
 
 jayson@^3.4.4:
   version "3.7.0"
@@ -10563,6 +11445,154 @@ jayson@^3.4.4:
     uuid "^8.3.2"
     ws "^7.4.5"
 
+jest-changed-files@30.4.1:
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-30.4.1.tgz#396fcf914165287f05960372a5d091f6f2275ec5"
+  integrity sha512-IuctmYrxi21iOSOaIXpJWalHyPAsVv0GeBHKDn8C1CA4W5htHn7INL+wdnL4Bo0+olEndvAFkmb++tIQJG+vvg==
+  dependencies:
+    execa "^5.1.1"
+    jest-util "30.4.1"
+    p-limit "^3.1.0"
+
+jest-circus@30.4.2:
+  version "30.4.2"
+  resolved "https://registry.yarnpkg.com/jest-circus/-/jest-circus-30.4.2.tgz#9a5b9b9c57bf51871f112ccf7a673d486c28f8e7"
+  integrity sha512-rvHH7VlY6LgbJXJTQ87GW62g1FntOtbhh0zT+v04kC+pgL6aBKyYINXxWukCpj3dcIBMw5/XUbtDS9dU9JTXeQ==
+  dependencies:
+    "@jest/environment" "30.4.1"
+    "@jest/expect" "30.4.1"
+    "@jest/test-result" "30.4.1"
+    "@jest/types" "30.4.1"
+    "@types/node" "*"
+    chalk "^4.1.2"
+    co "^4.6.0"
+    dedent "^1.6.0"
+    is-generator-fn "^2.1.0"
+    jest-each "30.4.1"
+    jest-matcher-utils "30.4.1"
+    jest-message-util "30.4.1"
+    jest-runtime "30.4.2"
+    jest-snapshot "30.4.1"
+    jest-util "30.4.1"
+    p-limit "^3.1.0"
+    pretty-format "30.4.1"
+    pure-rand "^7.0.0"
+    slash "^3.0.0"
+    stack-utils "^2.0.6"
+
+jest-cli@30.4.2:
+  version "30.4.2"
+  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-30.4.2.tgz#e353ef54035c5ac97f200807c97b3d857f52bddc"
+  integrity sha512-jfA2ocvVHMXS2QijrJ0d31ektP+d/W0T5RpcTX2Pq+3sVqHlsXVCM2+FmwpL+bdY8OfHpIg9xMxLF17Zg0U49Q==
+  dependencies:
+    "@jest/core" "30.4.2"
+    "@jest/test-result" "30.4.1"
+    "@jest/types" "30.4.1"
+    chalk "^4.1.2"
+    exit-x "^0.2.2"
+    import-local "^3.2.0"
+    jest-config "30.4.2"
+    jest-util "30.4.1"
+    jest-validate "30.4.1"
+    yargs "^17.7.2"
+
+jest-config@30.4.2:
+  version "30.4.2"
+  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-30.4.2.tgz#78f589b5410d2805518b8bdce517217fb96b5e61"
+  integrity sha512-rNHAShJQqQwFNoL0hbf3BphSBOWnpOUAKvidLS/AjNVLPfoj5mSf4jQMfW3cYOs6hXeZC7nF7mDHaBnbxELOzg==
+  dependencies:
+    "@babel/core" "^7.27.4"
+    "@jest/get-type" "30.1.0"
+    "@jest/pattern" "30.4.0"
+    "@jest/test-sequencer" "30.4.1"
+    "@jest/types" "30.4.1"
+    babel-jest "30.4.1"
+    chalk "^4.1.2"
+    ci-info "^4.2.0"
+    deepmerge "^4.3.1"
+    glob "^10.5.0"
+    graceful-fs "^4.2.11"
+    jest-circus "30.4.2"
+    jest-docblock "30.4.0"
+    jest-environment-node "30.4.1"
+    jest-regex-util "30.4.0"
+    jest-resolve "30.4.1"
+    jest-runner "30.4.2"
+    jest-util "30.4.1"
+    jest-validate "30.4.1"
+    parse-json "^5.2.0"
+    pretty-format "30.4.1"
+    slash "^3.0.0"
+    strip-json-comments "^3.1.1"
+
+jest-diff@30.4.1:
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-30.4.1.tgz#26691c73975768409af4a66b2754cea3182aa2dc"
+  integrity sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==
+  dependencies:
+    "@jest/diff-sequences" "30.4.0"
+    "@jest/get-type" "30.1.0"
+    chalk "^4.1.2"
+    pretty-format "30.4.1"
+
+jest-docblock@30.4.0:
+  version "30.4.0"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-30.4.0.tgz#3ab779a027d1495ae21550accd4266bbe99af7a3"
+  integrity sha512-ZPMabUZCx5MpbZ2eBYSvZ0J8fvo3dR9oM+eeUpb3aKNQFuS2tu3Duw1TNlMoP8k3WQgKGJuhcMFvwcVuq6T7oA==
+  dependencies:
+    detect-newline "^3.1.0"
+
+jest-each@30.4.1:
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-30.4.1.tgz#b69e66da8e2b578c6140d357f6574044c2a40537"
+  integrity sha512-/8MJbH6fuj48TstjrMf+u/pd06Qezz5xOXvZA6442heNOWr8bdeoGZX2d9fCn028CoMgYmroH9//zky5GfyYmA==
+  dependencies:
+    "@jest/get-type" "30.1.0"
+    "@jest/types" "30.4.1"
+    chalk "^4.1.2"
+    jest-util "30.4.1"
+    pretty-format "30.4.1"
+
+jest-environment-jsdom@^30.4.1:
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-30.4.1.tgz#928c81b3ea630b409fc6483cd16553b90b220bfc"
+  integrity sha512-o3nfaN4zej7qgk2X0j8Jhq/S9nAVKs2xK3QeQxeHVvpkEPxaA1yxDGydR+iVI7zPy7Cp62Aq2h3Ja46QvfWHGA==
+  dependencies:
+    "@jest/environment" "30.4.1"
+    "@jest/environment-jsdom-abstract" "30.4.1"
+    jsdom "^26.1.0"
+
+jest-environment-node@30.4.1:
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-30.4.1.tgz#43bbbee903e17d874eb1817195c50ff8b90e2fe0"
+  integrity sha512-4FZYVOk85hz2AyT6BbarKy9u37g6DbrDyCdFhsnDdXqyrueYQvB+0zO4f/kqLCRD0BsPRXPMNJeQwihKZV8naw==
+  dependencies:
+    "@jest/environment" "30.4.1"
+    "@jest/fake-timers" "30.4.1"
+    "@jest/types" "30.4.1"
+    "@types/node" "*"
+    jest-mock "30.4.1"
+    jest-util "30.4.1"
+    jest-validate "30.4.1"
+
+jest-haste-map@30.4.1:
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-30.4.1.tgz#6d80d09d668c20bf3944977e50acac94fcd672fe"
+  integrity sha512-rFrcONd8jeFsyw+Z9CrScJgglRf2+NFmNam8dKu7n+SoHqNYT47mn0DdEcVUZJpvh7Iz6/si7f7yUH7GJHVgnw==
+  dependencies:
+    "@jest/types" "30.4.1"
+    "@types/node" "*"
+    anymatch "^3.1.3"
+    fb-watchman "^2.0.2"
+    graceful-fs "^4.2.11"
+    jest-regex-util "30.4.0"
+    jest-util "30.4.1"
+    jest-worker "30.4.1"
+    picomatch "^4.0.3"
+    walker "^1.0.8"
+  optionalDependencies:
+    fsevents "^2.3.3"
+
 jest-haste-map@^28.1.3:
   version "28.1.3"
   resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-28.1.3.tgz#abd5451129a38d9841049644f34b034308944e2b"
@@ -10582,10 +11612,180 @@ jest-haste-map@^28.1.3:
   optionalDependencies:
     fsevents "^2.3.2"
 
+jest-leak-detector@30.4.1:
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-30.4.1.tgz#96077059a68e5871fc8f53aa90647a6a33f916cd"
+  integrity sha512-IpmyiioeHxiWDhesHnUFmOxcTzwCwKpgACgWajtAP+nYQXiY7DakTxB6Bx9JFiRMljr0AX1PvnQdaU1KFoz6NQ==
+  dependencies:
+    "@jest/get-type" "30.1.0"
+    pretty-format "30.4.1"
+
+jest-matcher-utils@30.4.1:
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-30.4.1.tgz#3fee8c89dbd8fc6e60eb590def9897e18f110ec4"
+  integrity sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==
+  dependencies:
+    "@jest/get-type" "30.1.0"
+    chalk "^4.1.2"
+    jest-diff "30.4.1"
+    pretty-format "30.4.1"
+
+jest-message-util@30.4.1:
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-30.4.1.tgz#40f6bfa5f564363edcba7ce0ca64277fd2ad6af7"
+  integrity sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==
+  dependencies:
+    "@babel/code-frame" "^7.27.1"
+    "@jest/types" "30.4.1"
+    "@types/stack-utils" "^2.0.3"
+    chalk "^4.1.2"
+    graceful-fs "^4.2.11"
+    jest-util "30.4.1"
+    picomatch "^4.0.3"
+    pretty-format "30.4.1"
+    slash "^3.0.0"
+    stack-utils "^2.0.6"
+
+jest-mock@30.4.1:
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-30.4.1.tgz#5e11a05d7719a1e3c7bba6348b70ff4e1bc5ea68"
+  integrity sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==
+  dependencies:
+    "@jest/types" "30.4.1"
+    "@types/node" "*"
+    jest-util "30.4.1"
+
+jest-pnp-resolver@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz#930b1546164d4ad5937d5540e711d4d38d4cad2e"
+  integrity sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==
+
+jest-regex-util@30.4.0:
+  version "30.4.0"
+  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-30.4.0.tgz#f75ccc43857633df2563a03588b5cb45c7c2941b"
+  integrity sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==
+
 jest-regex-util@^28.0.2:
   version "28.0.2"
   resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-28.0.2.tgz#afdc377a3b25fb6e80825adcf76c854e5bf47ead"
   integrity sha512-4s0IgyNIy0y9FK+cjoVYoxamT7Zeo7MhzqRGx7YDYmaQn1wucY9rotiGkBzzcMXTtjrCAP/f7f+E0F7+fxPNdw==
+
+jest-resolve-dependencies@30.4.2:
+  version "30.4.2"
+  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-30.4.2.tgz#152f8a4cb2dd351cedeb5ada53c89f9683a3ad92"
+  integrity sha512-gDiVh1I+GxYzz9oXlyw+1wv6VOYX1WYxMOfjsA3iGKePV2oxmbHhwxfkALxNxYy1ciw6APWwkW2zZONwP97aEQ==
+  dependencies:
+    jest-regex-util "30.4.0"
+    jest-snapshot "30.4.1"
+
+jest-resolve@30.4.1:
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-30.4.1.tgz#b9e432892dc0e2a470eb4826ef5f120a50b3205e"
+  integrity sha512-Zry8Yq/yJcNAZ7dJ5F2heic8AheXvbFZ7XI5V+h28nrYZ7Qoyy4dItq8OodjnYD270mvX+ZudmrNV9cysqhW5Q==
+  dependencies:
+    chalk "^4.1.2"
+    graceful-fs "^4.2.11"
+    jest-haste-map "30.4.1"
+    jest-pnp-resolver "^1.2.3"
+    jest-util "30.4.1"
+    jest-validate "30.4.1"
+    slash "^3.0.0"
+    unrs-resolver "^1.7.11"
+
+jest-runner@30.4.2:
+  version "30.4.2"
+  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-30.4.2.tgz#15debf3cb6d817538aa97427d5a79277cdff65fe"
+  integrity sha512-2dw0PslVYXxffXGpLo+Ejad+KcI1Qkjn7f4X4619gf21oCUmL+SPfjqIa/losUem3yEOvfNZe/F1HWUcNpODcg==
+  dependencies:
+    "@jest/console" "30.4.1"
+    "@jest/environment" "30.4.1"
+    "@jest/test-result" "30.4.1"
+    "@jest/transform" "30.4.1"
+    "@jest/types" "30.4.1"
+    "@types/node" "*"
+    chalk "^4.1.2"
+    emittery "^0.13.1"
+    exit-x "^0.2.2"
+    graceful-fs "^4.2.11"
+    jest-docblock "30.4.0"
+    jest-environment-node "30.4.1"
+    jest-haste-map "30.4.1"
+    jest-leak-detector "30.4.1"
+    jest-message-util "30.4.1"
+    jest-resolve "30.4.1"
+    jest-runtime "30.4.2"
+    jest-util "30.4.1"
+    jest-watcher "30.4.1"
+    jest-worker "30.4.1"
+    p-limit "^3.1.0"
+    source-map-support "0.5.13"
+
+jest-runtime@30.4.2:
+  version "30.4.2"
+  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-30.4.2.tgz#03b5955003440975b12e76518ec85d091c25b84a"
+  integrity sha512-3/5e8iPz2k/VLqlr8DgTftYyLUv8Su3FkCAO2/Od81UsUTpSxOrS6O5x5KkoQwyUjmpYyDJKeyAvg2T2nvpNkQ==
+  dependencies:
+    "@jest/environment" "30.4.1"
+    "@jest/fake-timers" "30.4.1"
+    "@jest/globals" "30.4.1"
+    "@jest/source-map" "30.0.1"
+    "@jest/test-result" "30.4.1"
+    "@jest/transform" "30.4.1"
+    "@jest/types" "30.4.1"
+    "@types/node" "*"
+    chalk "^4.1.2"
+    cjs-module-lexer "^2.1.0"
+    collect-v8-coverage "^1.0.2"
+    glob "^10.5.0"
+    graceful-fs "^4.2.11"
+    jest-haste-map "30.4.1"
+    jest-message-util "30.4.1"
+    jest-mock "30.4.1"
+    jest-regex-util "30.4.0"
+    jest-resolve "30.4.1"
+    jest-snapshot "30.4.1"
+    jest-util "30.4.1"
+    slash "^3.0.0"
+    strip-bom "^4.0.0"
+
+jest-snapshot@30.4.1:
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-30.4.1.tgz#0380cbbaa9d53d32cf7e61af98459ac10a339842"
+  integrity sha512-tEOkkfOMppUyeiHwjZswOQ3lcnoTnws/q5FnGIaeIh/jmoU0ZlgMYRR8sTlTj+nNGCoJ0RDq6SfxGxCsyMTPmw==
+  dependencies:
+    "@babel/core" "^7.27.4"
+    "@babel/generator" "^7.27.5"
+    "@babel/plugin-syntax-jsx" "^7.27.1"
+    "@babel/plugin-syntax-typescript" "^7.27.1"
+    "@babel/types" "^7.27.3"
+    "@jest/expect-utils" "30.4.1"
+    "@jest/get-type" "30.1.0"
+    "@jest/snapshot-utils" "30.4.1"
+    "@jest/transform" "30.4.1"
+    "@jest/types" "30.4.1"
+    babel-preset-current-node-syntax "^1.2.0"
+    chalk "^4.1.2"
+    expect "30.4.1"
+    graceful-fs "^4.2.11"
+    jest-diff "30.4.1"
+    jest-matcher-utils "30.4.1"
+    jest-message-util "30.4.1"
+    jest-util "30.4.1"
+    pretty-format "30.4.1"
+    semver "^7.7.2"
+    synckit "^0.11.8"
+
+jest-util@30.4.1:
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-30.4.1.tgz#979c9d014fdd12bb95d3dcde0192e1a9e0bc93d6"
+  integrity sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==
+  dependencies:
+    "@jest/types" "30.4.1"
+    "@types/node" "*"
+    chalk "^4.1.2"
+    ci-info "^4.2.0"
+    graceful-fs "^4.2.11"
+    picomatch "^4.0.3"
 
 jest-util@^28.1.3:
   version "28.1.3"
@@ -10599,6 +11799,43 @@ jest-util@^28.1.3:
     graceful-fs "^4.2.9"
     picomatch "^2.2.3"
 
+jest-validate@30.4.1:
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-30.4.1.tgz#dcc4784547bf644dca0226d3266fb1bde392c5a4"
+  integrity sha512-PDWi4SOwLnwqNDfHZjOcsEFyZ4fc/2W2gVL3DEoyqnB6jCQMLRtfBong8s6omIw3lI0HWOus12xfnFmQtjW3fw==
+  dependencies:
+    "@jest/get-type" "30.1.0"
+    "@jest/types" "30.4.1"
+    camelcase "^6.3.0"
+    chalk "^4.1.2"
+    leven "^3.1.0"
+    pretty-format "30.4.1"
+
+jest-watcher@30.4.1:
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-30.4.1.tgz#d2a78fd27553db9206947eeda6068d76bacfd276"
+  integrity sha512-/l9UonmvCwjHH7d2h3iAwIloLc1H0S8mJZ/LNK3i86hqwPAz8otUJjP9MfYtz9Tt77Su5FD2xGjZn8d31IZHlw==
+  dependencies:
+    "@jest/test-result" "30.4.1"
+    "@jest/types" "30.4.1"
+    "@types/node" "*"
+    ansi-escapes "^4.3.2"
+    chalk "^4.1.2"
+    emittery "^0.13.1"
+    jest-util "30.4.1"
+    string-length "^4.0.2"
+
+jest-worker@30.4.1:
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-30.4.1.tgz#ac010eb6c512425748a39e2d6bf05b2c4866ca4f"
+  integrity sha512-SHynN/q/QD++iNyvMdy+WMmbCGk8jIsNcRxycXbWubSOhvo6T+j2afcfUSl+3hYsiBebOTo0cT7c2H7CXugu1g==
+  dependencies:
+    "@types/node" "*"
+    "@ungap/structured-clone" "^1.3.0"
+    jest-util "30.4.1"
+    merge-stream "^2.0.0"
+    supports-color "^8.1.1"
+
 jest-worker@^28.1.3:
   version "28.1.3"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-28.1.3.tgz#7e3c4ce3fa23d1bb6accb169e7f396f98ed4bb98"
@@ -10607,6 +11844,16 @@ jest-worker@^28.1.3:
     "@types/node" "*"
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
+
+jest@^30.4.2:
+  version "30.4.2"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-30.4.2.tgz#e9bdb00f4bf1126d781b0d98e23130db096bbd9a"
+  integrity sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==
+  dependencies:
+    "@jest/core" "30.4.2"
+    "@jest/types" "30.4.1"
+    import-local "^3.2.0"
+    jest-cli "30.4.2"
 
 js-base64@^3.6.0:
   version "3.7.5"
@@ -10698,6 +11945,32 @@ jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
   integrity sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==
+
+jsdom@^26.1.0:
+  version "26.1.0"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-26.1.0.tgz#ab5f1c1cafc04bd878725490974ea5e8bf0c72b3"
+  integrity sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==
+  dependencies:
+    cssstyle "^4.2.1"
+    data-urls "^5.0.0"
+    decimal.js "^10.5.0"
+    html-encoding-sniffer "^4.0.0"
+    http-proxy-agent "^7.0.2"
+    https-proxy-agent "^7.0.6"
+    is-potential-custom-element-name "^1.0.1"
+    nwsapi "^2.2.16"
+    parse5 "^7.2.1"
+    rrweb-cssom "^0.8.0"
+    saxes "^6.0.0"
+    symbol-tree "^3.2.4"
+    tough-cookie "^5.1.1"
+    w3c-xmlserializer "^5.0.0"
+    webidl-conversions "^7.0.0"
+    whatwg-encoding "^3.1.1"
+    whatwg-mimetype "^4.0.0"
+    whatwg-url "^14.1.1"
+    ws "^8.18.0"
+    xml-name-validator "^5.0.0"
 
 jsesc@^2.5.1:
   version "2.5.2"
@@ -10925,6 +12198,11 @@ levelup@^4.3.2:
     level-supports "~1.0.0"
     xtend "~4.0.0"
 
+leven@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz#77891de834064cccba82ae7842bb6b14a13ed7f2"
+  integrity sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==
+
 levn@^0.4.1:
   version "0.4.1"
   resolved "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz"
@@ -11115,6 +12393,11 @@ lowercase-keys@^3.0.0:
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-3.0.0.tgz#c5e7d442e37ead247ae9db117a9d0a467c89d4f2"
   integrity sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==
 
+lru-cache@^10.2.0, lru-cache@^10.4.3:
+  version "10.4.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
+  integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
+
 lru-cache@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
@@ -11140,6 +12423,13 @@ ltgt@~2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ltgt/-/ltgt-2.2.1.tgz#f35ca91c493f7b73da0e07495304f17b31f87ee5"
   integrity sha512-AI2r85+4MquTw9ZYqabu4nMwy9Oftlfa/e/52t9IjtfG+mGBbTNdAoZ3RQKLHR6r0wQnwZnPIEh/Ya6XTWAKNA==
+
+make-dir@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-4.0.0.tgz#c3c2307a771277cd9638305f915c29ae741b614e"
+  integrity sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==
+  dependencies:
+    semver "^7.5.3"
 
 make-error@^1.1.1:
   version "1.3.6"
@@ -11274,6 +12564,11 @@ mimic-fn@^1.0.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
   integrity sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
 
+mimic-fn@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
+  integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
+
 mimic-function@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/mimic-function/-/mimic-function-5.0.1.tgz#acbe2b3349f99b9deaca7fb70e48b83e94e67076"
@@ -11306,7 +12601,7 @@ minimalistic-crypto-utils@^1.0.1:
   resolved "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz"
   integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
-minimatch@*, minimatch@5.0.1, minimatch@5.1.0, minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2, minimatch@^5.0.1, minimatch@^5.1.8:
+minimatch@*, minimatch@5.0.1, minimatch@5.1.0, minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2, minimatch@^5.0.1, minimatch@^5.1.8, minimatch@^9.0.4:
   version "5.1.9"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.9.tgz#1293ef15db0098b394540e8f9f744f9fda8dee4b"
   integrity sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==
@@ -11329,6 +12624,11 @@ minipass@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-5.0.0.tgz#3e9788ffb90b694a5d0ec94479a45b5d8738133d"
   integrity sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==
+
+"minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.1.2:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.3.tgz#79389b4eb1bb2d003a9bba87d492f2bd37bdc65b"
+  integrity sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==
 
 minizlib@^2.1.1:
   version "2.1.2"
@@ -11498,6 +12798,11 @@ nanoid@^3.3.12:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.15.tgz#36c490fad8c6e86c824c940dfdde999b69ed4316"
   integrity sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==
 
+napi-postinstall@^0.3.4:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/napi-postinstall/-/napi-postinstall-0.3.4.tgz#7af256d6588b5f8e952b9190965d6b019653bbb9"
+  integrity sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==
+
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz"
@@ -11593,6 +12898,13 @@ normalize-url@^6.0.1:
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-6.1.0.tgz#40d0885b535deffe3f3147bec877d05fe4c5668a"
   integrity sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==
 
+npm-run-path@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-4.0.1.tgz#b7ecd1e5ed53da8e37a55e1c2269e0b97ed748ea"
+  integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
+  dependencies:
+    path-key "^3.0.0"
+
 number-to-bn@1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/number-to-bn/-/number-to-bn-1.7.0.tgz#bb3623592f7e5f9e0030b1977bd41a0c53fe1ea0"
@@ -11600,6 +12912,11 @@ number-to-bn@1.7.0:
   dependencies:
     bn.js "4.11.6"
     strip-hex-prefix "1.0.0"
+
+nwsapi@^2.2.16:
+  version "2.2.24"
+  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.24.tgz#f8927043d4c9b516abdebe804a32c8d1f9484d1f"
+  integrity sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==
 
 oauth-sign@~0.9.0:
   version "0.9.0"
@@ -11704,6 +13021,13 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
+onetime@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.2.tgz#d0e96ebb56b07476df1dd9c4806e5237985ca45e"
+  integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
+  dependencies:
+    mimic-fn "^2.1.0"
+
 onetime@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-7.0.0.tgz#9f16c92d8c9ef5120e3acd9dd9957cceecc1ab60"
@@ -11756,7 +13080,7 @@ p-limit@^2.0.0, p-limit@^2.2.0:
   dependencies:
     p-try "^2.0.0"
 
-p-limit@^3.0.2:
+p-limit@^3.0.2, p-limit@^3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz"
   integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
@@ -11789,6 +13113,11 @@ p-try@^2.0.0:
   resolved "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
+package-json-from-dist@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz#4f1471a010827a86f94cfd9b0727e36d267de505"
+  integrity sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==
+
 pako@1.0.11:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
@@ -11816,7 +13145,7 @@ parse-headers@^2.0.0:
   resolved "https://registry.yarnpkg.com/parse-headers/-/parse-headers-2.0.5.tgz#069793f9356a54008571eb7f9761153e6c770da9"
   integrity sha512-ft3iAoLOB/MlwbNXgzy43SWGP6sQki2jQvAyBg/zDFAgr9bfNWZIUj42Kw2eJIl8kEi4PbgE6U1Zau/HwI75HA==
 
-parse-json@^5.0.0:
+parse-json@^5.0.0, parse-json@^5.2.0:
   version "5.2.0"
   resolved "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz"
   integrity sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==
@@ -11830,6 +13159,13 @@ parse-package-name@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/parse-package-name/-/parse-package-name-1.0.0.tgz#1a108757e4ffc6889d5e78bcc4932a97c097a5a7"
   integrity sha512-kBeTUtcj+SkyfaW4+KBe0HtsloBJ/mKTPoxpVdA57GZiPerREsUWJOhVj9anXweFiJkm5y8FG1sxFZkZ0SN6wg==
+
+parse5@^7.0.0, parse5@^7.2.1:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-7.3.0.tgz#d7e224fa72399c7a175099f45fc2ad024b05ec05"
+  integrity sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==
+  dependencies:
+    entities "^6.0.0"
 
 parseurl@~1.3.3:
   version "1.3.3"
@@ -11851,7 +13187,7 @@ path-is-absolute@^1.0.0:
   resolved "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
   integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
 
-path-key@^3.1.0:
+path-key@^3.0.0, path-key@^3.1.0:
   version "3.1.1"
   resolved "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
@@ -11860,6 +13196,14 @@ path-parse@^1.0.6, path-parse@^1.0.7:
   version "1.0.7"
   resolved "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
+
+path-scurry@^1.11.1:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-1.11.1.tgz#7960a668888594a0720b12a911d1a742ab9f11d2"
+  integrity sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==
+  dependencies:
+    lru-cache "^10.2.0"
+    minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
 
 path-to-regexp@0.1.7:
   version "0.1.7"
@@ -11948,10 +13292,17 @@ pino@7.11.0:
     sonic-boom "^2.2.1"
     thread-stream "^0.15.1"
 
-pirates@^4.0.4:
+pirates@^4.0.4, pirates@^4.0.7:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.7.tgz#643b4a18c4257c8a65104b73f3049ce9a0a15e22"
   integrity sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==
+
+pkg-dir@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
+  integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
+  dependencies:
+    find-up "^4.0.0"
 
 pngjs@^3.3.0:
   version "3.4.0"
@@ -12013,6 +13364,16 @@ prettier@^2.6.2:
   version "2.8.8"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
   integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
+
+pretty-format@30.4.1:
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-30.4.1.tgz#0911652e92e1e91f475e3e6a16e628e50649ea69"
+  integrity sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==
+  dependencies:
+    "@jest/schemas" "30.4.1"
+    ansi-styles "^5.2.0"
+    react-is-18 "npm:react-is@^18.3.1"
+    react-is-19 "npm:react-is@^19.2.5"
 
 process-nextick-args@~2.0.0:
   version "2.0.1"
@@ -12112,6 +13473,11 @@ punycode@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
+
+pure-rand@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/pure-rand/-/pure-rand-7.0.1.tgz#6f53a5a9e3e4a47445822af96821ca509ed37566"
+  integrity sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==
 
 qrcode.react@3.1.0, qrcode.react@^3.1.0:
   version "3.1.0"
@@ -12277,6 +13643,16 @@ react-icons@^4.4.0:
   version "4.7.1"
   resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-4.7.1.tgz#0f4b25a5694e6972677cb189d2a72eabea7a8345"
   integrity sha512-yHd3oKGMgm7zxo3EA7H2n7vxSoiGmHk5t6Ou4bXsfcgWyhfDKMpyKfhHR6Bjnn63c+YXBLBPUql9H4wPJM6sXw==
+
+"react-is-18@npm:react-is@^18.3.1":
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
+  integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
+
+"react-is-19@npm:react-is@^19.2.5":
+  version "19.2.7"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-19.2.7.tgz#57668ee86a78574a542b0a539455212b2c086df2"
+  integrity sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==
 
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
@@ -12530,6 +13906,13 @@ resolve-alpn@^1.0.0, resolve-alpn@^1.2.0:
   resolved "https://registry.yarnpkg.com/resolve-alpn/-/resolve-alpn-1.2.1.tgz#b7adbdac3546aaaec20b45e7d8265927072726f9"
   integrity sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==
 
+resolve-cwd@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-3.0.0.tgz#0f0075f1bb2544766cf73ba6a6e2adfebcb13f2d"
+  integrity sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==
+  dependencies:
+    resolve-from "^5.0.0"
+
 resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz"
@@ -12643,6 +14026,11 @@ rpc-websockets@^7.5.0:
     bufferutil "^4.0.1"
     utf-8-validate "^5.0.2"
 
+rrweb-cssom@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz#3021d1b4352fbf3b614aaeed0bc0d5739abe0bc2"
+  integrity sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==
+
 run-async@^2.2.0, run-async@^2.3.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
@@ -12710,7 +14098,7 @@ safe-stable-stringify@^2.1.0:
   resolved "https://registry.yarnpkg.com/safe-stable-stringify/-/safe-stable-stringify-2.4.2.tgz#ec7b037768098bf65310d1d64370de0dc02353aa"
   integrity sha512-gMxvPJYhP0O9n2pvcfYfIuYgbledAOJFcqRThtPRmjscaipiwcwPPKLytpVzMkG2HAN87Qmo2d4PtGiri1dSLA==
 
-"safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
+"safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
@@ -12723,6 +14111,13 @@ sass@^1.56.1:
     chokidar ">=3.0.0 <4.0.0"
     immutable "^4.0.0"
     source-map-js ">=0.6.2 <2.0.0"
+
+saxes@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/saxes/-/saxes-6.0.0.tgz#fe5b4a4768df4f14a201b1ba6a65c1f3d9988cc5"
+  integrity sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==
+  dependencies:
+    xmlchars "^2.2.0"
 
 scheduler@^0.23.0:
   version "0.23.0"
@@ -12788,6 +14183,11 @@ semver@^7.3.7, semver@^7.3.8:
   integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
   dependencies:
     lru-cache "^6.0.0"
+
+semver@^7.5.3, semver@^7.5.4, semver@^7.7.2:
+  version "7.8.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.5.tgz#39b646037dd50c14fb451e7e4cac58ed8b863f69"
+  integrity sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==
 
 send@0.18.0:
   version "0.18.0"
@@ -12947,12 +14347,12 @@ side-channel@^1.1.1:
     side-channel-map "^1.0.1"
     side-channel-weakmap "^1.0.2"
 
-signal-exit@^3.0.2, signal-exit@^3.0.7:
+signal-exit@^3.0.2, signal-exit@^3.0.3, signal-exit@^3.0.7:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
 
-signal-exit@^4.1.0:
+signal-exit@^4.0.1, signal-exit@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
   integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
@@ -13014,10 +14414,23 @@ source-map-js@^1.2.1:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
 
+source-map-support@0.5.13:
+  version "0.5.13"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.13.tgz#31b24a9c2e73c2de85066c0feb7d44767ed52932"
+  integrity sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
 source-map@^0.5.7:
   version "0.5.7"
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
   integrity sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==
+
+source-map@^0.6.0:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
 split-on-first@^1.0.0:
   version "1.1.0"
@@ -13048,6 +14461,13 @@ sshpk@^1.7.0:
     jsbn "~0.1.0"
     safer-buffer "^2.0.2"
     tweetnacl "~0.14.0"
+
+stack-utils@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-2.0.6.tgz#aaf0748169c02fc33c8232abccf933f54a1cc34f"
+  integrity sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==
+  dependencies:
+    escape-string-regexp "^2.0.0"
 
 statuses@2.0.1:
   version "2.0.1"
@@ -13087,6 +14507,23 @@ string-convert@^0.2.0:
   resolved "https://registry.yarnpkg.com/string-convert/-/string-convert-0.2.1.tgz#6982cc3049fbb4cd85f8b24568b9d9bf39eeff97"
   integrity sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A==
 
+string-length@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/string-length/-/string-length-4.0.2.tgz#a8a8dc7bd5c1a82b9b3c8b87e125f66871b6e57a"
+  integrity sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==
+  dependencies:
+    char-regex "^1.0.2"
+    strip-ansi "^6.0.0"
+
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
 string-width@^2.0.0, string-width@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
@@ -13104,7 +14541,7 @@ string-width@^3.0.0, string-width@^3.1.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
 
-string-width@^4.1.0, string-width@^4.2.0:
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -13112,6 +14549,15 @@ string-width@^4.1.0, string-width@^4.2.0:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
+
+string-width@^5.0.1, string-width@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-5.1.2.tgz#14f8daec6d81e7221d2a357e668cab73bdbca794"
+  integrity sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==
+  dependencies:
+    eastasianwidth "^0.2.0"
+    emoji-regex "^9.2.2"
+    strip-ansi "^7.0.1"
 
 string-width@^7.0.0:
   version "7.2.0"
@@ -13176,6 +14622,13 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
 strip-ansi@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
@@ -13204,7 +14657,7 @@ strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   dependencies:
     ansi-regex "^5.0.1"
 
-strip-ansi@^7.1.0, strip-ansi@^7.1.2:
+strip-ansi@^7.0.1, strip-ansi@^7.1.0, strip-ansi@^7.1.2:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.2.0.tgz#d22a269522836a627af8d04b5c3fd2c7fa3e32e3"
   integrity sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==
@@ -13215,6 +14668,16 @@ strip-bom@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz"
   integrity sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==
+
+strip-bom@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-4.0.0.tgz#9c3505c1db45bcedca3d9cf7a16f5c5aa3901878"
+  integrity sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==
+
+strip-final-newline@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
+  integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
 
 strip-hex-prefix@1.0.0:
   version "1.0.0"
@@ -13251,7 +14714,7 @@ superstruct@^0.14.2:
   resolved "https://registry.yarnpkg.com/superstruct/-/superstruct-0.14.2.tgz#0dbcdf3d83676588828f1cf5ed35cda02f59025b"
   integrity sha512-nPewA6m9mR3d6k7WkZ8N8zpTWfenFH3q9pA2PkuiZxINr9DKB2+40wEQf0ixn8VaGuJ78AB6iWOtStI+/4FKZQ==
 
-supports-color@8.1.1, supports-color@^8.0.0:
+supports-color@8.1.1, supports-color@^8.0.0, supports-color@^8.1.1:
   version "8.1.1"
   resolved "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz"
   integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
@@ -13308,6 +14771,18 @@ symbol-observable@^2.0.3:
   version "2.0.3"
   resolved "https://registry.npmjs.org/symbol-observable/-/symbol-observable-2.0.3.tgz"
   integrity sha512-sQV7phh2WCYAn81oAkakC5qjq2Ml0g8ozqz03wOGnx9dDlG1de6yrF+0RAzSJD8fPUow3PTSMf2SAbOGxb93BA==
+
+symbol-tree@^3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
+  integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
+
+synckit@^0.11.8:
+  version "0.11.13"
+  resolved "https://registry.yarnpkg.com/synckit/-/synckit-0.11.13.tgz#062a5ea57d81befc35892f8254de5c567e97c80a"
+  integrity sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==
+  dependencies:
+    "@pkgr/core" "^0.3.6"
 
 tar@^4.0.2, tar@^6.2.1:
   version "6.2.1"
@@ -13448,7 +14923,7 @@ toidentifier@1.0.1:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
 
-tough-cookie@^4.1.3, tough-cookie@~2.5.0:
+tough-cookie@^4.1.3, tough-cookie@^5.1.1, tough-cookie@~2.5.0:
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.1.4.tgz#945f1461b45b5a8c76821c33ea49c3ac192c1b36"
   integrity sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==
@@ -13457,6 +14932,13 @@ tough-cookie@^4.1.3, tough-cookie@~2.5.0:
     punycode "^2.1.1"
     universalify "^0.2.0"
     url-parse "^1.5.3"
+
+tr46@^5.1.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-5.1.1.tgz#96ae867cddb8fdb64a49cc3059a8d428bcf238ca"
+  integrity sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==
+  dependencies:
+    punycode "^2.3.1"
 
 tr46@~0.0.3:
   version "0.0.3"
@@ -13538,7 +15020,7 @@ type-check@^0.4.0, type-check@~0.4.0:
   dependencies:
     prelude-ls "^1.2.1"
 
-type-detect@^4.0.0, type-detect@^4.0.5:
+type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.5:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
@@ -13547,6 +15029,11 @@ type-fest@^0.20.2:
   version "0.20.2"
   resolved "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz"
   integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
+
+type-fest@^0.21.3:
+  version "0.21.3"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
+  integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
 
 type-is@~1.6.18:
   version "1.6.18"
@@ -13677,6 +15164,36 @@ unpipe@1.0.0, unpipe@~1.0.0:
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
   integrity sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==
 
+unrs-resolver@^1.7.11:
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/unrs-resolver/-/unrs-resolver-1.12.2.tgz#a6c6888396abba5adaac4cab6587df866f1d7afd"
+  integrity sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==
+  dependencies:
+    napi-postinstall "^0.3.4"
+  optionalDependencies:
+    "@unrs/resolver-binding-android-arm-eabi" "1.12.2"
+    "@unrs/resolver-binding-android-arm64" "1.12.2"
+    "@unrs/resolver-binding-darwin-arm64" "1.12.2"
+    "@unrs/resolver-binding-darwin-x64" "1.12.2"
+    "@unrs/resolver-binding-freebsd-x64" "1.12.2"
+    "@unrs/resolver-binding-linux-arm-gnueabihf" "1.12.2"
+    "@unrs/resolver-binding-linux-arm-musleabihf" "1.12.2"
+    "@unrs/resolver-binding-linux-arm64-gnu" "1.12.2"
+    "@unrs/resolver-binding-linux-arm64-musl" "1.12.2"
+    "@unrs/resolver-binding-linux-loong64-gnu" "1.12.2"
+    "@unrs/resolver-binding-linux-loong64-musl" "1.12.2"
+    "@unrs/resolver-binding-linux-ppc64-gnu" "1.12.2"
+    "@unrs/resolver-binding-linux-riscv64-gnu" "1.12.2"
+    "@unrs/resolver-binding-linux-riscv64-musl" "1.12.2"
+    "@unrs/resolver-binding-linux-s390x-gnu" "1.12.2"
+    "@unrs/resolver-binding-linux-x64-gnu" "1.12.2"
+    "@unrs/resolver-binding-linux-x64-musl" "1.12.2"
+    "@unrs/resolver-binding-openharmony-arm64" "1.12.2"
+    "@unrs/resolver-binding-wasm32-wasi" "1.12.2"
+    "@unrs/resolver-binding-win32-arm64-msvc" "1.12.2"
+    "@unrs/resolver-binding-win32-ia32-msvc" "1.12.2"
+    "@unrs/resolver-binding-win32-x64-msvc" "1.12.2"
+
 update-browserslist-db@^1.0.9:
   version "1.0.10"
   resolved "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz"
@@ -13793,6 +15310,15 @@ v8-compile-cache-lib@^3.0.1:
   resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
   integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
 
+v8-to-istanbul@^9.0.1:
+  version "9.3.0"
+  resolved "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz#b9572abfa62bd556c16d75fdebc1a411d5ff3175"
+  integrity sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==
+  dependencies:
+    "@jridgewell/trace-mapping" "^0.3.12"
+    "@types/istanbul-lib-coverage" "^2.0.1"
+    convert-source-map "^2.0.0"
+
 valtio@1.9.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/valtio/-/valtio-1.9.0.tgz#d5d9f664319eaf18dd98f758d50495eca28eb0b8"
@@ -13819,6 +15345,13 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
+
+w3c-xmlserializer@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz#f925ba26855158594d907313cedd1476c5967f6c"
+  integrity sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==
+  dependencies:
+    xml-name-validator "^5.0.0"
 
 wagmi@^0.11.5:
   version "0.11.5"
@@ -14085,6 +15618,11 @@ webidl-conversions@^3.0.0:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
   integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
 
+webidl-conversions@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-7.0.0.tgz#256b4e1882be7debbf01d05f0aa2039778ea080a"
+  integrity sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==
+
 websocket@^1.0.32:
   version "1.0.34"
   resolved "https://registry.yarnpkg.com/websocket/-/websocket-1.0.34.tgz#2bdc2602c08bf2c82253b730655c0ef7dcab3111"
@@ -14096,6 +15634,26 @@ websocket@^1.0.32:
     typedarray-to-buffer "^3.1.5"
     utf-8-validate "^5.0.2"
     yaeti "^0.0.6"
+
+whatwg-encoding@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz#d0f4ef769905d426e1688f3e34381a99b60b76e5"
+  integrity sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==
+  dependencies:
+    iconv-lite "0.6.3"
+
+whatwg-mimetype@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz#bc1bf94a985dc50388d54a9258ac405c3ca2fc0a"
+  integrity sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==
+
+whatwg-url@^14.0.0, whatwg-url@^14.1.1:
+  version "14.2.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-14.2.0.tgz#4ee02d5d725155dae004f6ae95c73e7ef5d95663"
+  integrity sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==
+  dependencies:
+    tr46 "^5.1.0"
+    webidl-conversions "^7.0.0"
 
 whatwg-url@^5.0.0:
   version "5.0.0"
@@ -14170,6 +15728,15 @@ workerpool@6.2.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrap-ansi@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-5.1.0.tgz#1fd1f67235d5b6d0fee781056001bfb694c03b09"
@@ -14188,14 +15755,14 @@ wrap-ansi@^6.2.0:
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
 
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+wrap-ansi@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-8.1.0.tgz#56dc22368ee570face1b49819975d9b9a5ead214"
+  integrity sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==
   dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
+    ansi-styles "^6.1.0"
+    string-width "^5.0.1"
+    strip-ansi "^7.0.1"
 
 wrap-ansi@^9.0.0:
   version "9.0.2"
@@ -14219,7 +15786,15 @@ write-file-atomic@^4.0.1:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.7"
 
-ws@7.4.6, ws@7.5.3, ws@^3.0.0, ws@^7, ws@^7.4.0, ws@^7.4.5, ws@^7.5.1, ws@^8.20.1, ws@^8.5.0:
+write-file-atomic@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-5.0.1.tgz#68df4717c55c6fa4281a7860b4c2ba0a6d2b11e7"
+  integrity sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==
+  dependencies:
+    imurmurhash "^0.1.4"
+    signal-exit "^4.0.1"
+
+ws@7.4.6, ws@7.5.3, ws@^3.0.0, ws@^7, ws@^7.4.0, ws@^7.4.5, ws@^7.5.1, ws@^8.18.0, ws@^8.20.1, ws@^8.5.0:
   version "8.21.0"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.0.tgz#012e413fc07429945121b0c153158c4343086951"
   integrity sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==
@@ -14253,6 +15828,16 @@ xhr@^2.0.4, xhr@^2.3.3:
     is-function "^1.0.1"
     parse-headers "^2.0.0"
     xtend "^4.0.0"
+
+xml-name-validator@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-5.0.0.tgz#82be9b957f7afdacf961e5980f1bf227c0bf7673"
+  integrity sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==
+
+xmlchars@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
+  integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
 xstream@^11.14.0:
   version "11.14.0"
@@ -14323,6 +15908,11 @@ yargs-parser@^20.2.2:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
 
+yargs-parser@^21.1.1:
+  version "21.1.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
+  integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
+
 yargs-unparser@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/yargs-unparser/-/yargs-unparser-2.0.0.tgz#f131f9226911ae5d9ad38c432fe809366c2325eb"
@@ -14378,6 +15968,19 @@ yargs@^15.3.1:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
+
+yargs@^17.7.2:
+  version "17.7.3"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.3.tgz#779dffe6bcafec596a7172e983289a588647faaa"
+  integrity sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==
+  dependencies:
+    cliui "^8.0.1"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.1.1"
 
 yn@3.1.1:
   version "3.1.1"


### PR DESCRIPTION
Closes #217.

## What

Lets existing AssetMantle **V1 keystore users log into the V2 wallet** by importing their file, and adds passkey (biometric) unlock — replacing the current "go to v1.wallet.assetmantle.one" redirect for keystore. Also adds modern encrypted-file import/export round-trip.

Before this PR the keystore flow in the repo was a **non-functional UI skeleton** (no crypto, imported nowhere); production redirected keystore users to V1.

## Critical finding driving the design: the V1 keystore is effectively unencrypted

V1's `createKeyStore` stores the raw AES-256 key **inside the file** (the field misnamed `salt` is the key), and the password is only an unsalted `sha512` equality check that never derives the key. So a V1 keystore file is a plaintext-equivalent seed. This PR therefore **reads** the V1 format but **never writes** it: legacy import is decrypt-only, followed by a forced re-encryption to a modern format the user downloads, with a warning that the old file is compromised-by-design.

## How

- `lib/keystore/legacyV1.js` — decrypt-only V1 reproduction, browser-native Web Crypto (SHA-512 + AES-256-CBC), byte-verified against the real V1 source.
- `lib/keystore/modern.js` + `account.js` — cosmjs `DirectSecp256k1HdWallet.serialize/deserialize` (Argon2id + XChaCha20-Poly1305) and secp256k1 derivation at the **exact V1 path** `m/44'/118'/0'/0/0`, prefix `mantle` (verified against V1 config), so a migrated mnemonic keeps its address.
- `lib/keystore/keystoreWallet.js` + `keystoreStore.js` — a custom cosmos-kit wallet adapter feeding the in-memory signer, so **`data/txApi.js` and every send/stake/vote/trade path are unchanged**. Guarded to the AssetMantle chain only (fails closed — can't hand a mantle key to gravity/osmosis).
- `lib/keystore/passkey.js` — WebAuthn **PRF** unlock. Passkeys are P-256 and can't sign secp256k1, so the passkey never signs; its PRF-derived 32-byte secret is used as the password to the modern keystore. Password path is the fallback where PRF is unsupported.
- `lib/keystore/persist.js` / `download.js` — opt-in localStorage of only `{credentialId, prfSalt, modernBlob}` (never a key/mnemonic/legacy blob); encrypted-file download.
- `views/ConnectModal/KeystoreConnect.js` — the real connect/import/upgrade/export/passkey flow, wired into the production modal.

## Security

Ran a **level-3 adversarial security review** (money/security path): **zero Critical, zero High** — no key/mnemonic/PRF-secret exfiltration path (logs, thrown strings, analytics, SSR payload, storage), chain guard fails closed, never writes the broken V1 format, no new runtime deps. Two Mediums + two Lows it raised are **fixed** in this branch: user-facing exports now use a freshly-typed password (not the device-bound passkey secret — prevents an undecryptable backup), the mnemonic/unlock-secret live in refs not React state, deferred object-URL revoke, and `userVerification: required` on WebAuthn. Net verdict: a **security improvement** over users hand-carrying plaintext-equivalent V1 files. Residual risk is the inherent browser-software-wallet XSS surface; the recommended compensating control (a strict CSP) is filed as #224.

## Testing

- **27 unit tests** (jest — this PR also stands up the repo's first test framework): legacy decrypt (incl. wrong-password, corrupted-ciphertext, malformed), modern round-trip, account derivation, adapter address-match + chain-guard + disconnect-clears-key, passkey PRF round-trip through the real modern keystore + empty-secret guard + fallback, persist allowlist, download.
- `yarn build` passes.
- **Not yet done (needs a browser — stated, not faked):** the interactive click-through — real Touch ID / platform-authenticator PRF round trip, file picker, download prompts. This is the one remaining manual verification pass before merge; I'll do it on a testnet account.

## Scope

In: migrate V1 files, modern import/export, passkey unlock, mainnet `assetmantle`. Out (documented): Ledger (keeps V1 redirect), generating a brand-new wallet, watch-only mode, non-default HD indices, testnet.

Built subagent-driven, test-first, task-by-task with per-task review. **Not merged** — needs explicit approval and the manual browser pass.