### PR TITLE
fix: restore layout=fill on next/image components (regression from #223)

### DIFF
--- a/components/DisconnecedRecieve.jsx
+++ b/components/DisconnecedRecieve.jsx
@@ -18,7 +18,7 @@ const DisconnecedRecieve = () => {
             aspectRatio: "1/1",
           }}
         >
-          <Image src="/qr-code.svg" alt="qr code place holder" />
+          <Image layout="fill" src="/qr-code.svg" alt="qr code place holder" />
         </div>
         <h4 className="body2 text-primary">Wallet Address</h4>
         <div className="d-flex align-items-center justify-content-center gap-2 text-gray text-center caption2 pt-1">

--- a/components/ICFormPolygon.js
+++ b/components/ICFormPolygon.js
@@ -126,7 +126,11 @@ export default function ICFormPolygon() {
               className="position-relative"
               style={{ width: "21px", aspectRatio: "1/1" }}
             >
-              <Image src="/chainLogos/grav.svg" alt="Gravity Bridge" />
+              <Image
+                layout="fill"
+                src="/chainLogos/grav.svg"
+                alt="Gravity Bridge"
+              />
             </div>
             <h5 className="caption2 text-primary">Gravity Bridge</h5>
           </div>
@@ -180,7 +184,11 @@ export default function ICFormPolygon() {
               className="position-relative"
               style={{ width: "21px", aspectRatio: "1/1" }}
             >
-              <Image src="/chainLogos/eth.svg" alt="Ethereum Chain" />
+              <Image
+                layout="fill"
+                src="/chainLogos/eth.svg"
+                alt="Ethereum Chain"
+              />
             </div>
             <h5 className="caption2 text-primary">Ethereum Chain</h5>
           </div>
@@ -243,7 +251,11 @@ export default function ICFormPolygon() {
               className="position-relative"
               style={{ width: "21px", aspectRatio: "1/1" }}
             >
-              <Image src="/chainLogos/polygon.svg" alt="Polygon Chain" />
+              <Image
+                layout="fill"
+                src="/chainLogos/polygon.svg"
+                alt="Polygon Chain"
+              />
             </div>
             <h5 className="caption2 text-primary">Polygon Chain</h5>
           </div>

--- a/views/Header.js
+++ b/views/Header.js
@@ -84,7 +84,12 @@ export default function Header({ setLeftCol }) {
     >
       <Link href="/">
         <a>
-          <Image src={NavBarData.logo} alt={NavBarData.title} priority={true} />
+          <Image
+            layout="fill"
+            src={NavBarData.logo}
+            alt={NavBarData.title}
+            priority={true}
+          />
         </a>
       </Link>
     </div>


### PR DESCRIPTION
## Production regression from #223

PR #223 (dead-code/deps tidy) removed `layout="fill"` attributes in bulk to clean up leftovers from an old `<Image>`→`<img>` conversion. The blanket removal also stripped it from **5 real `next/image` `<Image>` components**, which *require* `width`/`height` or `layout`:

- `views/Header.js` — the logo (renders on **every page**; SSR-errors the whole app in dev, degrades in prod)
- `components/DisconnecedRecieve.jsx` — the receive QR placeholder
- `components/ICFormPolygon.js` — 3 Polygon-bridge chain logos (grav/eth/polygon)

`next build` passed in #223 because next/image only **hard-errors on missing dimensions in dev**; production degrades silently — which is why CI didn't catch it and it shipped.

## Fix

Restores `layout="fill"` on exactly those 5 `<Image>` components (their parent containers are already sized for fill layout — this returns them to their pre-#223 working state). Plain `<img>` tags that also had the (invalid-on-img) attribute removed are correctly left alone.

## Verification

Caught by the **live browser E2E** of the keystore feature: the dev server threw `Image with src "/logo.svg" must use width/height or layout='fill'` on load. After this fix the full app renders (logo, QR, nav, connect flow all verified in-browser). `next build` passes.

Should be merged and deployed promptly — production is currently affected.